### PR TITLE
docs: document secret handling guidelines

### DIFF
--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -135,6 +135,7 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 ## Global PR Gates (Every Phase)
 - [ ] Code + unit tests implemented
 - [ ] Docs updated (README/USAGE/SRS/plan/workflow/checklist)
+- [ ] No API credentials or other secrets committed; `.gitignore` covers sensitive files
 - [ ] CI green; pre-commit clean
 - [ ] Manual smoke test (dry-run or paper) demonstrated
 - [ ] Follow-ups/issues logged for next phases

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -54,6 +54,20 @@
 
 ---
 
+#### Phase A3: Credential hygiene
+**Deliverables**
+- No API keys or account credentials committed to the repository
+- `.gitignore` entries for `.env`, real `settings.ini`, and other sensitive files
+
+**Checklist**
+- [ ] Secrets stored outside the repo (env vars or untracked files)
+- [ ] `.gitignore` prevents committing credential files
+
+**Acceptance**
+- Manual scan confirms repository is free of credentials
+
+---
+
 ### Milestone B — Inputs, Validation, & State
 
 #### Phase B1: Config loader & schema validation

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -10,9 +10,10 @@
 
 1. **Decide repo name** (e.g., `ibkr-rebalancer`).  
 2. **Create GitHub repo** (private).  
-3. **Install** Python 3.10+ (or Miniconda) on Windows.  
-4. **Install** IBKR TWS or IB Gateway and enable API (127.0.0.1:4002).  
+3. **Install** Python 3.10+ (or Miniconda) on Windows.
+4. **Install** IBKR TWS or IB Gateway and enable API (127.0.0.1:4002).
 5. **Prepare paper account** credentials and confirm it connects manually in TWS.
+6. **Keep credentials out of version control** — store secrets in environment variables or gitignored files.
 
 ---
 


### PR DESCRIPTION
## Summary
- note that API credentials should never be committed and belong in .gitignore
- add reminder in workflow setup to keep secrets out of version control
- extend global checklist with secret-scanning gate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72e2d9f388320be9748211198a98d