### PR TITLE
Clarify D2 logging requirements

### DIFF
--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -110,6 +110,7 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 - [ ] Timestamped CSV written to `reports/`
 - [ ] CSV includes all SRS columns: `timestamp_run`, `account_id`, `symbol`, `is_cash`, `target_wt_pct`, `current_wt_pct`, `drift_pct`, `drift_usd`, `action`, `qty_shares`, `est_price`, `order_type`, `algo`, `est_value_usd`, `pre_gross_exposure`, `post_gross_exposure`, `pre_leverage`, `post_leverage`, `status`, `error`, `notes`
 - [ ] Logs include INFO/ERROR messages for validation and order states
+- [ ] Logs capture connection events, pacing/backoff messages, and a final summary
 - [ ] Unit tests check CSV schema and content
 
 ---

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -219,8 +219,8 @@
 - Unified logs (INFO/ERROR) embedded in main log
 
 **Tests**
-- [ ] CSV schema round-trips in tests  
-- [ ] Log messages include validation failures and order states
+- [ ] CSV schema round-trips in tests
+- [ ] Log messages include IBKR connection events, pacing/backoff notices, validation failures, order states, and final run summaries
 
 **Acceptance**
 - A full run generates a CSV with expected rows/columns and statuses

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -381,7 +381,7 @@ Proceed? [y/N]:
 
 **Implement** `src/io/reporting.py`
 - Write **timestamped CSV** per run under `reports/` with columns `timestamp_run`, `account_id`, `symbol`, `is_cash`, `target_wt_pct`, `current_wt_pct`, `drift_pct`, `drift_usd`, `action`, `qty_shares`, `est_price`, `order_type`, `algo`, `est_value_usd`, `pre_gross_exposure`, `post_gross_exposure`, `pre_leverage`, `post_leverage`, `status`, `error`, `notes`.
-- Unified INFO/ERROR log lines; include validation aborts and order states.
+- Unified INFO/ERROR log lines; capture connection events, pacing/backoff messages, validation aborts, order states, and a final summary.
 
 **Tests**: schema round-trip; presence of all SRS columns; status transitions captured.
 


### PR DESCRIPTION
## Summary
- Expand Phase D2 tests to require logging of IBKR connection events, pacing/backoff notices, and final run summaries
- Note in workflow that logs must capture connection events, pacing/backoff messages, and a final summary
- Add checklist item verifying those log entries for Phase D2

## Testing
- `pre-commit run --files dev-plan/plan.md dev-plan/workflow.md dev-plan/checklist.md` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b72ef6cacc8320a0f58c5ec40ae116