### PR TITLE
docs: update repo name in setup guide

### DIFF
--- a/dev-plan/101.md
+++ b/dev-plan/101.md
@@ -10,7 +10,7 @@ Hi! This guide shows **exactly** how to test and accept each phase of the IBKR E
 - Download and install **Anaconda** for Windows (just click “Next” until it finishes).
 
 ### 0.2 Make a project folder
-- Put the unzipped **ibkr-rebalancer** folder somewhere easy, like `C:\Users\YourName\Documents\`.
+- Put the unzipped **IB_Simple** folder somewhere easy, like `C:\Users\YourName\Documents\`.
 
 ### 0.3 Open **Anaconda Prompt**
 - Press the Windows key, type **Anaconda Prompt**, and open it.
@@ -24,11 +24,11 @@ You should see `(ibkr-rebal)` at the beginning of the line now.
 
 ### 0.5 Go into the project
 ```bat
-cd path\to\ibkr-rebalancer
+cd path\to\IB_Simple
 ```
 Example:
 ```bat
-cd C:\Users\YourName\Documents\ibkr-rebalancer
+cd C:\Users\YourName\Documents\IB_Simple
 ```
 
 ### 0.6 Install the tools
@@ -59,7 +59,7 @@ For each phase below, you’ll do three things:
 **Do this:**
 ```bat
 conda activate ibkr-rebal
-cd path\to\ibkr-rebalancer
+cd path\to\IB_Simple
 pre-commit run --all-files
 pytest -q -m "not integration"
 ```
@@ -307,7 +307,7 @@ When it asks `Proceed? [y/N]:` type **y** and hit **Enter**.
 - **Permission error?** Close any programs using the files and try again.
 - **TWS/Gateway connection fails?** Open TWS (paper) → Settings → API enabled; correct **port** (usually 4002). Update `config/settings.ini`.
 - **Pip failed?** Run `python -m pip install --upgrade pip` and try `pip install -r requirements.txt` again.
-- **Weird Windows path?** Use quotes: `cd "C:\\Users\\YourName\\Documents\\ibkr-rebalancer"`.
+- **Weird Windows path?** Use quotes: `cd "C:\\Users\\YourName\\Documents\\IB_Simple"`.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify project folder name as `IB_Simple`
- update example `cd` commands and Phase A1 instructions to match `IB_Simple`

## Testing
- `pre-commit run --all-files` *(fails: mypy cannot find config file / type annotations missing)*
- `pytest -q -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_68b7360fc5f483208e2cbb276c99bc53