### PR TITLE
ci: upgrade pip before installing requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements.txt') }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests


### PR DESCRIPTION
## Summary
- upgrade pip after caching in CI workflow
- install dependencies from requirements.txt

## Testing
- `pip install -r requirements.txt`
- `pre-commit run --files .github/workflows/ci.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b737ecfa008320ab6fdb0c00cdc63b