### PR TITLE
ci: run non-integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,10 @@ jobs:
         run: mypy src || true
         shell: bash
       - name: Run tests
-        run: pytest
+        run: pytest -q -m "not integration"
       - name: Upload reports
         if: ${{ hashFiles('reports/**') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: reports
           path: reports/
-        run: pytest -q -m "not integration"


### PR DESCRIPTION
## Summary
- run non-integration tests in CI workflow

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73f4ed5348320b796881c3c89f027