### PR TITLE
chore: use ruff check command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run ruff
-        run: ruff .
+        run: ruff check .
       - name: Run black
         run: black --check .
       - name: Run isort

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -332,7 +332,7 @@ jobs:
           pip install pytest pytest-cov ruff black mypy
       - name: Lint & Format
         run: |
-          ruff .
+          ruff check .
           black --check .
       - name: Type check
         run: mypy src || true  # optional relax

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -200,7 +200,7 @@ jobs:
           pip install pytest pytest-cov ruff black isort mypy
       - name: Lint & Format
         run: |
-          ruff .
+          ruff check .
           black --check .
           isort --check-only .
       - name: Type check
@@ -422,7 +422,7 @@ Proceed? [y/N]:
 
 ```bash
 # Lint/format/type check
-ruff . && black --check . && isort --check-only . && mypy src
+ruff check . && black --check . && isort --check-only . && mypy src
 
 # Run unit tests only
 pytest -q -m "not integration"


### PR DESCRIPTION
## Summary
- use `ruff check .` in GitHub Actions CI workflow
- document `ruff check .` usage in development plans
## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `mypy src`
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b742fd32dc8320928fa59414bfd67d