### PR TITLE
Expose config dataclasses from io package

### DIFF
--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -1,5 +1,30 @@
-"""IO utilities for IB_Simple."""
+"""IO utilities for IB_Simple.
 
-from .config_loader import AppConfig, ConfigError, load_config
+This package exposes the configuration loader along with the dataclasses it
+produces.  Importing from :mod:`src.io` gives convenient access to these
+types without reaching into the underlying modules.
+"""
 
-__all__ = ["AppConfig", "ConfigError", "load_config"]
+from .config_loader import (
+    AppConfig,
+    ConfigError,
+    Execution,
+    IBKR,
+    IO,
+    Models,
+    Pricing,
+    Rebalance,
+    load_config,
+)
+
+__all__ = [
+    "AppConfig",
+    "IBKR",
+    "Models",
+    "Rebalance",
+    "Pricing",
+    "Execution",
+    "IO",
+    "ConfigError",
+    "load_config",
+]


### PR DESCRIPTION
## Summary
- re-export configuration dataclasses (IBKR, Models, Rebalance, Pricing, Execution, IO) from `src.io`
- document package purpose and ensure `load_config` and `ConfigError` remain available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b747ab5a7c832093910376fb1e342c