### PR TITLE
chore: format test_config_loader for Black compliance

### DIFF
--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -5,8 +5,17 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from src.io.config_loader import (IBKR, IO, AppConfig, ConfigError, Execution,
-                                  Models, Pricing, Rebalance, load_config)
+from src.io.config_loader import (
+    IBKR,
+    IO,
+    AppConfig,
+    ConfigError,
+    Execution,
+    Models,
+    Pricing,
+    Rebalance,
+    load_config,
+)
 
 VALID_CONFIG = """\
 [ibkr]


### PR DESCRIPTION
## Summary
- format tests/unit/test_config_loader.py with Black for consistent style

## Testing
- `black --check tests/unit/test_config_loader.py`
- `pytest tests/unit/test_config_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74bdde78c8320bab2c23c5c054cb3