### PR TITLE
Align import formatting and fix mypy configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        args: ["--profile=black"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.mypy]
-mypy_path = ["src"]
 plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 explicit_package_bases = true

--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -5,8 +5,17 @@ produces.  Importing from :mod:`src.io` gives convenient access to these
 types without reaching into the underlying modules.
 """
 
-from .config_loader import (IBKR, IO, AppConfig, ConfigError, Execution,
-                            Models, Pricing, Rebalance, load_config)
+from .config_loader import (
+    IBKR,
+    IO,
+    AppConfig,
+    ConfigError,
+    Execution,
+    Models,
+    Pricing,
+    Rebalance,
+    load_config,
+)
 
 __all__ = [
     "AppConfig",

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -5,8 +5,17 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from src.io.config_loader import (IBKR, IO, AppConfig, ConfigError, Execution,
-                                  Models, Pricing, Rebalance, load_config)
+from src.io.config_loader import (
+    IBKR,
+    IO,
+    AppConfig,
+    ConfigError,
+    Execution,
+    Models,
+    Pricing,
+    Rebalance,
+    load_config,
+)
 
 VALID_CONFIG = """\
 [ibkr]


### PR DESCRIPTION
## Summary
- configure isort to use black profile for consistent formatting
- remove mypy_path setting to avoid duplicate module names
- format imports in IO utilities and tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74bd768d4832088513fc447a07f6d