### PR TITLE
Fail CI on mypy errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run isort
         run: isort --check-only .
       - name: Type check
-        run: mypy src || true
+        run: mypy src
         shell: bash
       - name: Run tests
         run: pytest -q -m "not integration"


### PR DESCRIPTION
## Summary
- enforce mypy to fail the CI by removing the `|| true` escape in the workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74df8068883208a41723bbc84a1f4