### PR TITLE
chore: separate dev dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ hashFiles('requirements.txt') }}
+          key: pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Run ruff
         run: ruff check .
       - name: Run black

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd ibkr-rebalancer
 py -3.10 -m venv .venv
 . .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install
 pytest -q -m "not integration"
 ```

--- a/dev-plan/101.md
+++ b/dev-plan/101.md
@@ -34,7 +34,7 @@ cd C:\Users\YourName\Documents\IB_Simple
 ### 0.6 Install the tools
 ```bat
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install
 ```
 If you see warnings, that’s okay. If you see big red **ERROR** lines, tell an adult or check the Troubleshooting section at the bottom.
@@ -333,7 +333,7 @@ When it asks `Proceed? [y/N]:` type **y** and hit **Enter**.
 - **Command not found?** Make sure the **Anaconda Prompt** is open and the env is active: `conda activate ibkr-rebal`.
 - **Permission error?** Close any programs using the files and try again.
 - **TWS/Gateway connection fails?** Open TWS (paper) → Settings → API enabled; correct **port** (usually 4002). Update `config/settings.ini`.
-- **Pip failed?** Run `python -m pip install --upgrade pip` and try `pip install -r requirements.txt` again.
+- **Pip failed?** Run `python -m pip install --upgrade pip` and try `pip install -r requirements.txt -r requirements-dev.txt` again.
 - **Weird Windows path?** Use quotes: `cd "C:\\Users\\YourName\\Documents\\IB_Simple"`.
 
 ---

--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -9,7 +9,7 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 ### Phase A1 — Repo Scaffold & Local Environment
 - [ ] Repo created and `main` branch protected
 - [ ] Directory structure scaffolded (`src/`, `tests/`, `config/`, `data/`, `reports/`)
-- [ ] `requirements.txt` or `pyproject.toml` committed
+- [ ] `requirements.txt`, `requirements-dev.txt` or `pyproject.toml` committed
 - [ ] `.editorconfig`, `.gitignore`, `.pre-commit-config.yaml` committed
 - [ ] Virtual environment created; dependencies install without error
 - [ ] `pre-commit install` works; `pre-commit run --all-files` passes

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -25,13 +25,13 @@
 - `README.md` with quickstart
 - Base repo structure:
   - `src/` (code), `tests/` (pytest), `reports/` (output), `config/` (sample `settings.ini`), `data/` (sample `portfolios.csv`)
-- `.editorconfig`, `.gitignore`, `requirements.txt` / `pyproject.toml`
+- `.editorconfig`, `.gitignore`, `requirements.txt`, `requirements-dev.txt` / `pyproject.toml`
 - `pre-commit` hooks (black, isort, ruff/flake8)
 
 **Checklist**
 - [ ] Install Python 3.10+ (Windows)  
 - [ ] Create venv or conda env  
-- [ ] Install dependencies (`pip install -r requirements.txt`)  
+- [ ] Install dependencies (`pip install -r requirements.txt -r requirements-dev.txt`)  
 - [ ] Configure pre-commit: `pre-commit install`
 
 **Acceptance**
@@ -284,7 +284,7 @@
 1) **Windows + Python**
 - Install Python 3.10+ (or Miniconda); ensure `python --version`
 - Create env: `python -m venv .venv` (or `conda create -n ibkr-rebal python=3.10`)
-- Activate env; `pip install -r requirements.txt`
+- Activate env; `pip install -r requirements.txt -r requirements-dev.txt`
 
 2) **IBKR TWS/Gateway**
 - Install and run TWS or IB Gateway (paper)  
@@ -328,7 +328,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
           pip install pytest pytest-cov ruff black mypy
       - name: Lint & Format
         run: |

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -39,7 +39,7 @@ ibkr-rebalancer/
 │  └─ settings.ini      # sample
 ├─ reports/             # output (gitignored)
 ├─ README.md
-├─ requirements.txt (or pyproject.toml)
+├─ requirements.txt, requirements-dev.txt (or pyproject.toml)
 ├─ .pre-commit-config.yaml
 ├─ .editorconfig
 ├─ .gitignore
@@ -53,7 +53,7 @@ cd ibkr-rebalancer
 py -3.10 -m venv .venv
 . .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install
 ```
 
@@ -65,12 +65,17 @@ typing-extensions
 pydantic>=2  # optional, helpful schemas
 rich         # optional pretty CLI
 click        # optional CLI flags
+```
+
+**`requirements-dev.txt`**
+```
 pytest
 pytest-cov
 ruff
 black
 isort
 mypy         # optional
+pre-commit
 ```
 
 **.gitignore**
@@ -196,7 +201,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
           pip install pytest pytest-cov ruff black isort mypy
       - name: Lint & Format
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-cov
+ruff
+black
+isort
+mypy
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,3 @@ typing-extensions
 pydantic>=2
 rich
 click
-pytest
-pytest-cov
-ruff
-black
-isort
-mypy


### PR DESCRIPTION
## Summary
- move testing and linting tools to new requirements-dev.txt
- update docs and CI to install runtime and dev requirements separately

## Testing
- `pre-commit run --files requirements.txt requirements-dev.txt README.md dev-plan/workflow.md dev-plan/plan.md dev-plan/checklist.md dev-plan/101.md .github/workflows/ci.yaml`
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b74dfdfc308320a10186390141a0a8