### PR TITLE
Use PYTHONPATH for src layout tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ py -3.10 -m venv .venv
 python -m pip install --upgrade pip
 pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install
+$env:PYTHONPATH = "."
 pytest -q -m "not integration"
 ```
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for IB_Simple."""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,9 +1,6 @@
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from src.io.config_loader import (
     IBKR,


### PR DESCRIPTION
## Summary
- drop inline path hacking from `test_config_loader`
- document setting `PYTHONPATH` for running tests
- add module docstring for `src` package

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b74f6c158c83209bfbd5c928802774