### PR TITLE
Add portfolio CSV loader

### DIFF
--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -16,6 +16,7 @@ from .config_loader import (
     Rebalance,
     load_config,
 )
+from .portfolio_csv import PortfolioCSVError, load_portfolios
 
 __all__ = [
     "AppConfig",
@@ -27,4 +28,6 @@ __all__ = [
     "Pricing",
     "Rebalance",
     "load_config",
+    "PortfolioCSVError",
+    "load_portfolios",
 ]

--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -1,0 +1,95 @@
+"""Portfolio CSV loader for IB_Simple."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict
+
+
+class PortfolioCSVError(Exception):
+    """Raised when portfolio CSV validation fails."""
+
+
+def _parse_percent(value: str, *, symbol: str, model: str) -> float:
+    """Parse a percentage string into a float between 0 and 100."""
+
+    text = value.strip()
+    if not text:
+        return 0.0
+    if text.endswith("%"):
+        text = text[:-1]
+    try:
+        pct = float(text)
+    except ValueError as exc:
+        raise PortfolioCSVError(
+            f"{symbol}: invalid percentage for {model}: {value!r}"
+        ) from exc
+    if pct < 0 or pct > 100:
+        raise PortfolioCSVError(f"{symbol}: percent out of range for {model}: {pct}")
+    return pct
+
+
+def load_portfolios(path: Path) -> dict[str, dict[str, float]]:
+    """Load portfolio model weights from ``path``.
+
+    Parameters
+    ----------
+    path:
+        CSV file containing columns ``ETF, SMURF, BADASS, GLTR`` with
+        percentage strings.
+    """
+
+    with path.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        fieldnames = reader.fieldnames
+        if fieldnames is None:
+            raise PortfolioCSVError("Missing header")
+        expected = ["ETF", "SMURF", "BADASS", "GLTR"]
+        if len(fieldnames) != len(set(fieldnames)):
+            dupes = [n for n in fieldnames if fieldnames.count(n) > 1]
+            raise PortfolioCSVError(f"Duplicate columns: {', '.join(dupes)}")
+        if set(fieldnames) != set(expected):
+            extra = set(fieldnames) - set(expected)
+            missing = set(expected) - set(fieldnames)
+            parts = []
+            if extra:
+                parts.append(f"Unknown columns: {', '.join(sorted(extra))}")
+            if missing:
+                parts.append(f"Missing columns: {', '.join(sorted(missing))}")
+            raise PortfolioCSVError("; ".join(parts))
+
+        portfolios: Dict[str, Dict[str, float]] = {}
+        for row in reader:
+            symbol = (row.get("ETF") or "").strip()
+            if not symbol:
+                raise PortfolioCSVError("Blank ETF symbol")
+            if symbol in portfolios:
+                raise PortfolioCSVError(f"Duplicate ETF symbol: {symbol}")
+            weights: Dict[str, float] = {}
+            for model in ("SMURF", "BADASS", "GLTR"):
+                raw = row.get(model) or ""
+                weight = _parse_percent(raw, symbol=symbol, model=model)
+                weights[model.lower()] = weight
+            portfolios[symbol] = weights
+    return portfolios
+
+
+def main(path: str) -> None:
+    """Validate and load ``path`` printing ``OK`` on success."""
+
+    try:
+        load_portfolios(Path(path))
+    except PortfolioCSVError as exc:
+        print(exc)
+        raise SystemExit(1)
+    print("OK")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python -m src.io.portfolio_csv <CSV_PATH>")
+        raise SystemExit(1)
+    main(sys.argv[1])

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.io.portfolio_csv import PortfolioCSVError, load_portfolios
+
+
+def test_load_portfolios_valid(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,GLTR
+BLOK,50%,,0%
+SPY,,25%,50%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    portfolios = load_portfolios(path)
+    assert portfolios == {
+        "BLOK": {"smurf": 50.0, "badass": 0.0, "gltr": 0.0},
+        "SPY": {"smurf": 0.0, "badass": 25.0, "gltr": 50.0},
+    }
+
+
+def test_unknown_column(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,GLTR,FOO
+BLOK,0%,0%,0%,0%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    with pytest.raises(PortfolioCSVError):
+        load_portfolios(path)
+
+
+def test_duplicate_column(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,SMURF
+BLOK,0%,0%,0%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    with pytest.raises(PortfolioCSVError):
+        load_portfolios(path)
+
+
+def test_malformed_percent(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,GLTR
+BLOK,abc,0%,0%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    with pytest.raises(PortfolioCSVError):
+        load_portfolios(path)


### PR DESCRIPTION
## Summary
- add parser to read ETF model weights from CSV
- expose loader via `src.io`
- test percent parsing and header validation

## Testing
- `pre-commit run --files src/io/portfolio_csv.py src/io/__init__.py tests/unit/test_portfolio_csv.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7567126b4832083d138dfa0b7aafd