### PR TITLE
Add ETF symbol validation using ib_async

### DIFF
--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -16,7 +16,7 @@ from .config_loader import (
     Rebalance,
     load_config,
 )
-from .portfolio_csv import PortfolioCSVError, load_portfolios
+from .portfolio_csv import PortfolioCSVError, load_portfolios, validate_symbols
 
 __all__ = [
     "AppConfig",
@@ -30,4 +30,5 @@ __all__ = [
     "load_config",
     "PortfolioCSVError",
     "load_portfolios",
+    "validate_symbols",
 ]

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -5,7 +5,34 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+import src.io.portfolio_csv as portfolio_csv
 from src.io.portfolio_csv import PortfolioCSVError, load_portfolios
+
+
+class FakeIB:
+    def __init__(self) -> None:
+        from ib_async.contract import ContractDetails, Stock
+
+        self.mapping = {
+            "BLOK": ContractDetails(
+                contract=Stock("BLOK", currency="USD"), stockType="ETF"
+            ),
+            "SPY": ContractDetails(
+                contract=Stock("SPY", currency="USD"), stockType="ETF"
+            ),
+        }
+
+    def reqContractDetails(self, contract):
+        symbol = contract.symbol
+        detail = self.mapping.get(symbol)
+        return [detail] if detail else []
+
+
+@pytest.fixture(autouse=True)
+def fake_ib(monkeypatch):
+    ib = FakeIB()
+    monkeypatch.setattr(portfolio_csv, "IB", lambda: ib)
+    return ib
 
 
 def test_load_portfolios_valid(tmp_path: Path) -> None:
@@ -82,6 +109,17 @@ BLOK,0%,0%,0%
 def test_malformed_percent(tmp_path: Path) -> None:
     content = """ETF,SMURF,BADASS,GLTR
 BLOK,abc,0%,0%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    with pytest.raises(PortfolioCSVError):
+        load_portfolios(path)
+
+
+def test_unknown_symbol(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,GLTR
+FAKE,50%,50%,50%
+CASH,50%,50%,50%
 """
     path = tmp_path / "pf.csv"
     path.write_text(content)

--- a/tests/unit/test_validate_symbols.py
+++ b/tests/unit/test_validate_symbols.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import pytest
+from ib_async.contract import ContractDetails, Stock
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import src.io.portfolio_csv as portfolio_csv
+from src.io.portfolio_csv import PortfolioCSVError
+
+
+class FakeIB:
+    def __init__(self) -> None:
+        self.mapping = {
+            "BLOK": ContractDetails(
+                contract=Stock("BLOK", currency="USD"), stockType="ETF"
+            ),
+            "SPY": ContractDetails(
+                contract=Stock("SPY", currency="USD"), stockType="ETF"
+            ),
+        }
+        self.calls: list[str] = []
+
+    def reqContractDetails(self, contract):
+        self.calls.append(contract.symbol)
+        detail = self.mapping.get(contract.symbol)
+        return [detail] if detail else []
+
+
+def setup_fake_ib(monkeypatch) -> FakeIB:
+    ib = FakeIB()
+    monkeypatch.setattr(portfolio_csv, "IB", lambda: ib)
+    return ib
+
+
+def test_validate_symbols_valid(monkeypatch) -> None:
+    ib = setup_fake_ib(monkeypatch)
+    portfolio_csv.validate_symbols(["BLOK", "SPY"])
+    assert ib.calls == ["BLOK", "SPY"]
+
+
+def test_validate_symbols_unknown(monkeypatch) -> None:
+    ib = setup_fake_ib(monkeypatch)
+    with pytest.raises(PortfolioCSVError):
+        portfolio_csv.validate_symbols(["BLOK", "BAD"])
+    assert ib.calls == ["BLOK", "BAD"]
+
+
+def test_validate_symbols_skips_cash(monkeypatch) -> None:
+    ib = setup_fake_ib(monkeypatch)
+    portfolio_csv.validate_symbols(["CASH", "SPY"])
+    assert ib.calls == ["SPY"]


### PR DESCRIPTION
## Summary
- validate ETFs against IB contract details to ensure USD-denominated funds
- export new helper and integrate into portfolio CSV loader
- cover symbol validation with unit tests and CASH exclusion

## Testing
- `pre-commit run --files src/io/portfolio_csv.py src/io/__init__.py tests/unit/test_portfolio_csv.py tests/unit/test_validate_symbols.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b758e4fb388320806205f40bed96c7