### PR TITLE
Add portfolio validation CLI

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -132,23 +132,3 @@ def load_portfolios(path: Path) -> dict[str, dict[str, float]]:
                     f"{combined:.2f}%, expected 100%"
                 )
     return portfolios
-
-
-def main(path: str) -> None:
-    """Validate and load ``path`` printing ``OK`` on success."""
-
-    try:
-        load_portfolios(Path(path))
-    except PortfolioCSVError as exc:
-        print(exc)
-        raise SystemExit(1)
-    print("OK")
-
-
-if __name__ == "__main__":  # pragma: no cover - CLI utility
-    import sys
-
-    if len(sys.argv) != 2:
-        print("Usage: python -m src.io.portfolio_csv <CSV_PATH>")
-        raise SystemExit(1)
-    main(sys.argv[1])

--- a/src/io/validate_portfolios.py
+++ b/src/io/validate_portfolios.py
@@ -1,0 +1,27 @@
+"""Validate portfolio CSV files for IB_Simple."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .portfolio_csv import PortfolioCSVError, load_portfolios
+
+
+def main(path: str) -> None:
+    """Validate and load ``path`` printing ``OK`` on success."""
+
+    try:
+        load_portfolios(Path(path))
+    except PortfolioCSVError as exc:
+        print(exc)
+        raise SystemExit(1)
+    print("OK")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python -m src.io.validate_portfolios <CSV_PATH>")
+        raise SystemExit(1)
+    main(sys.argv[1])

--- a/tests/unit/test_validate_portfolios_cli.py
+++ b/tests/unit/test_validate_portfolios_cli.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_ok(tmp_path: Path) -> None:
+    csv = tmp_path / "pf.csv"
+    csv.write_text("ETF,SMURF,BADASS,GLTR\nCASH,100%,100%,100%\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "src.io.validate_portfolios", str(csv)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "OK"
+
+
+def test_cli_error(tmp_path: Path) -> None:
+    csv = tmp_path / "pf.csv"
+    csv.write_text("ETF,SMURF,BADASS\nCASH,100%,100%\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "src.io.validate_portfolios", str(csv)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Missing columns" in result.stdout


### PR DESCRIPTION
## Summary
- add `validate_portfolios` CLI entrypoint that loads and checks portfolio CSV files
- move CLI handling out of `portfolio_csv`
- add tests covering CLI success and failure cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75a8c281c8320964e56ad159d8c92