### PR TITLE
docs: add portfolio validation CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ pytest -q -m "not integration"
 python -m src.io.validate_config config/settings.ini
 ```
 
+### Validate portfolio CSV
+```bash
+python -m src.io.validate_portfolios data/portfolios.csv
+```
+
 ### Dry run
 ```bash
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv

--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -40,13 +40,13 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 - [x] CLI `src/io/validate_config.py` for config validation
 
 ### Phase B2 — CSV Parser & Portfolio Validation
-- [ ] `src/io/portfolio_csv.py` implemented
-- [ ] Blanks parsed as 0%; percent strings handled
-- [ ] Per-model sums ≈ 100% (±0.01)
-- [ ] If `CASH` present: Sum(assets)+CASH ≈ 100% (±0.01)
-- [ ] ETF symbols validated against IBKR's list; unknown symbols abort
-- [ ] Invalid CSV aborts with actionable error
-- [ ] Unit tests cover CASH ±, malformed %, unknown columns
+- [x] `src/io/portfolio_csv.py` implemented
+- [x] Blanks parsed as 0%; percent strings handled
+- [x] Per-model sums ≈ 100% (±0.01)
+- [x] If `CASH` present: Sum(assets)+CASH ≈ 100% (±0.01)
+- [x] ETF symbols validated against IBKR's list; unknown symbols abort
+- [x] Invalid CSV aborts with actionable error
+- [x] Unit tests cover CASH ±, malformed %, unknown columns
 
 ### Phase B3 — IBKR Connection & Snapshot (Paper)
 - [ ] `src/broker/ibkr_client.py` implemented

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -433,6 +433,9 @@ pre-commit run --all-files
 # Run unit tests only
 pytest -q -m "not integration"
 
+# Validate portfolio CSV
+python -m src.io.validate_portfolios data/portfolios.csv
+
 # Dry-run preview
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
 


### PR DESCRIPTION
## Summary
- document portfolio CSV validation in README and workflow notes
- check off completed portfolio-validation tasks in dev checklist

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75d299948832080ebf165da887c1d