### PR TITLE
Connect validate_symbols to IBKR and config-driven CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ python -m src.io.validate_config config/settings.ini
 
 ### Validate portfolio CSV
 ```bash
-python -m src.io.validate_portfolios data/portfolios.csv
+python -m src.io.validate_portfolios --config config/settings.ini data/portfolios.csv
 ```
+An active IBKR session (TWS or IB Gateway) must be running so the tool can
+verify ticker symbols.
 
 ### Account snapshot (paper)
 ```bash

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -33,10 +33,17 @@ class FakeIB:
             s: ContractDetails(contract=Stock(s, currency="USD"), stockType="ETF")
             for s in symbols
         }
+        self.connected = False
 
     def reqContractDetails(self, contract):
         detail = self.mapping.get(contract.symbol)
         return [detail] if detail else []
+
+    def connect(self, host, port, clientId):  # noqa: N803 - upstream camelCase
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
 
 
 @pytest.fixture(autouse=True)
@@ -55,7 +62,9 @@ def portfolios_csv(tmp_path: Path) -> Path:
 
 
 def test_load_portfolios_valid(portfolios_csv: Path) -> None:
-    portfolios = load_portfolios(portfolios_csv)
+    portfolios = load_portfolios(
+        portfolios_csv, host="127.0.0.1", port=4001, client_id=1
+    )
     # there are 14 rows including CASH
     assert len(portfolios) == 14
     assert portfolios["IAU"]["gltr"] == 100.0
@@ -69,7 +78,7 @@ CASH,50%,75%,50%
 """
     path = tmp_path / "pf.csv"
     path.write_text(content)
-    portfolios = load_portfolios(path)
+    portfolios = load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
     assert portfolios["CASH"] == {"smurf": 50.0, "badass": 75.0, "gltr": 50.0}
 
 
@@ -81,7 +90,7 @@ CASH,-10%,75%,-10%
 """
     path = tmp_path / "pf.csv"
     path.write_text(content)
-    portfolios = load_portfolios(path)
+    portfolios = load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
     assert portfolios["CASH"]["smurf"] == -10.0
 
 
@@ -94,7 +103,7 @@ SPY,,25%,50%
     path.write_text(content)
     msg = r"SMURF: totals 50\.00% do not sum to 100%"
     with pytest.raises(PortfolioCSVError, match=msg):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
 
 
 def test_cash_mismatch(tmp_path: Path) -> None:
@@ -107,7 +116,7 @@ CASH,40%,70%,30%
     path.write_text(content)
     msg = r"SMURF: assets 50\.00% \+ CASH 40\.00% = 90\.00%, expected 100%"
     with pytest.raises(PortfolioCSVError, match=msg):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
 
 
 def test_unknown_column(tmp_path: Path) -> None:
@@ -117,7 +126,7 @@ BLOK,0%,0%,0%,0%
     path = tmp_path / "pf.csv"
     path.write_text(content)
     with pytest.raises(PortfolioCSVError, match=r"Unknown columns: FOO"):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
 
 
 def test_duplicate_column(tmp_path: Path) -> None:
@@ -127,7 +136,7 @@ BLOK,0%,0%,0%
     path = tmp_path / "pf.csv"
     path.write_text(content)
     with pytest.raises(PortfolioCSVError, match=r"Duplicate columns: SMURF"):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
 
 
 @pytest.mark.parametrize(
@@ -142,7 +151,7 @@ def test_malformed_percent(tmp_path: Path, value: str, expected: str) -> None:
     path = tmp_path / "pf.csv"
     path.write_text(content)
     with pytest.raises(PortfolioCSVError, match=re.escape(expected)):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)
 
 
 def test_unknown_symbol(tmp_path: Path) -> None:
@@ -153,4 +162,4 @@ CASH,50%,50%,50%
     path = tmp_path / "pf.csv"
     path.write_text(content)
     with pytest.raises(PortfolioCSVError, match=r"Unknown ETF symbol: FAKE"):
-        load_portfolios(path)
+        load_portfolios(path, host="127.0.0.1", port=4001, client_id=1)

--- a/tests/unit/test_validate_portfolios_cli.py
+++ b/tests/unit/test_validate_portfolios_cli.py
@@ -6,8 +6,16 @@ from pathlib import Path
 def test_cli_ok(tmp_path: Path) -> None:
     csv = tmp_path / "pf.csv"
     csv.write_text("ETF,SMURF,BADASS,GLTR\nCASH,100%,100%,100%\n")
+    cfg = Path(__file__).resolve().parents[2] / "config" / "settings.ini"
     result = subprocess.run(
-        [sys.executable, "-m", "src.io.validate_portfolios", str(csv)],
+        [
+            sys.executable,
+            "-m",
+            "src.io.validate_portfolios",
+            "--config",
+            str(cfg),
+            str(csv),
+        ],
         capture_output=True,
         text=True,
     )
@@ -18,8 +26,16 @@ def test_cli_ok(tmp_path: Path) -> None:
 def test_cli_error(tmp_path: Path) -> None:
     csv = tmp_path / "pf.csv"
     csv.write_text("ETF,SMURF,BADASS\nCASH,100%,100%\n")
+    cfg = Path(__file__).resolve().parents[2] / "config" / "settings.ini"
     result = subprocess.run(
-        [sys.executable, "-m", "src.io.validate_portfolios", str(csv)],
+        [
+            sys.executable,
+            "-m",
+            "src.io.validate_portfolios",
+            "--config",
+            str(cfg),
+            str(csv),
+        ],
         capture_output=True,
         text=True,
     )

--- a/tests/unit/test_validate_symbols.py
+++ b/tests/unit/test_validate_symbols.py
@@ -21,11 +21,18 @@ class FakeIB:
             ),
         }
         self.calls: list[str] = []
+        self.connected: bool = False
 
     def reqContractDetails(self, contract):
         self.calls.append(contract.symbol)
         detail = self.mapping.get(contract.symbol)
         return [detail] if detail else []
+
+    def connect(self, host, port, clientId):  # noqa: N803 (upstream uses camelCase)
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
 
 
 def setup_fake_ib(monkeypatch) -> FakeIB:
@@ -36,18 +43,24 @@ def setup_fake_ib(monkeypatch) -> FakeIB:
 
 def test_validate_symbols_valid(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
-    portfolio_csv.validate_symbols(["BLOK", "SPY"])
+    portfolio_csv.validate_symbols(
+        ["BLOK", "SPY"], host="127.0.0.1", port=4001, client_id=1
+    )
     assert ib.calls == ["BLOK", "SPY"]
 
 
 def test_validate_symbols_unknown(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
     with pytest.raises(PortfolioCSVError):
-        portfolio_csv.validate_symbols(["BLOK", "BAD"])
+        portfolio_csv.validate_symbols(
+            ["BLOK", "BAD"], host="127.0.0.1", port=4001, client_id=1
+        )
     assert ib.calls == ["BLOK", "BAD"]
 
 
 def test_validate_symbols_skips_cash(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
-    portfolio_csv.validate_symbols(["CASH", "SPY"])
+    portfolio_csv.validate_symbols(
+        ["CASH", "SPY"], host="127.0.0.1", port=4001, client_id=1
+    )
     assert ib.calls == ["SPY"]


### PR DESCRIPTION
## Summary
- connect `validate_symbols` to an IBKR session using provided host/port/client id
- pass connection details through `load_portfolios` and new `--config` option for CLI
- document the new option and requirement for a running IBKR session

## Testing
- ⚠️ `pre-commit run --files README.md src/io/portfolio_csv.py src/io/validate_portfolios.py tests/unit/test_portfolio_csv.py tests/unit/test_validate_portfolios_cli.py tests/unit/test_validate_symbols.py` *(pre-commit not installed and installation failed: network unreachable)*
- ⚠️ `pytest -q -m "not integration"` *(pytest not installed and installation failed: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7662498f8832085733d1945286991