### PR TITLE
Add pricing utility with snapshot fallback

### DIFF
--- a/src/core/pricing.py
+++ b/src/core/pricing.py
@@ -1,0 +1,75 @@
+"""Utility functions for fetching prices from Interactive Brokers.
+
+This module exposes :func:`get_price` which retrieves a price for a given
+symbol using an :class:`ib_async.IB` connection.  The desired price field is
+specified via the ``price_source`` argument which maps to an attribute on the
+returned ticker.  Common values are ``"last"``, ``"close"``, ``"bid"`` and
+``"ask"``.
+
+If the requested field is missing and ``fallback_to_snapshot`` is ``True`` the
+function retries the request with ``snapshot=True`` to obtain delayed market
+data.  A :class:`PricingError` is raised when no price can be determined.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ib_async.contract import Stock
+
+
+class PricingError(Exception):
+    """Raised when a price cannot be obtained for a symbol."""
+
+
+async def get_price(
+    ib: Any,
+    symbol: str,
+    *,
+    price_source: str,
+    fallback_to_snapshot: bool,
+) -> float:
+    """Return the price for ``symbol`` using market data from IB.
+
+    Parameters
+    ----------
+    ib:
+        Connected :class:`ib_async.IB` instance used to request market data.
+    symbol:
+        Ticker symbol to query (USD stocks or ETFs).
+    price_source:
+        Name of the price field to extract from the returned ticker.  Typical
+        values include ``"last"``, ``"close"``, ``"bid"`` and ``"ask"`` but any
+        attribute present on the ticker is supported.
+    fallback_to_snapshot:
+        When ``True`` and the initial realtime request yields ``None`` for the
+        requested field, the function performs a second request with
+        ``snapshot=True`` to fetch delayed data.  The snapshot is not attempted
+        when set to ``False``.
+
+    Returns
+    -------
+    float
+        The price value extracted from the ticker.
+
+    Raises
+    ------
+    PricingError
+        If no price can be determined after the optional snapshot fallback.
+    """
+
+    # Initial realtime market data request
+    tickers = await ib.reqTickersAsync(Stock(symbol=symbol, currency="USD"))
+    price = getattr(tickers[0], price_source, None) if tickers else None
+
+    # If no price and snapshot fallback is enabled, try again with snapshot
+    if price is None and fallback_to_snapshot:
+        tickers = await ib.reqTickersAsync(
+            Stock(symbol=symbol, currency="USD"), snapshot=True
+        )
+        price = getattr(tickers[0], price_source, None) if tickers else None
+
+    if price is None:
+        raise PricingError(f"No price available for {symbol} using {price_source}")
+
+    return float(price)

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -1,0 +1,48 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.core.pricing import PricingError, get_price
+
+
+class FakeIB:
+    def __init__(self, *responses):
+        # responses is a list of lists of ticker objects
+        self.responses = list(responses)
+        self.calls = []
+
+    async def reqTickersAsync(self, contract, *, snapshot=False):  # pragma: no cover - simple stub
+        self.calls.append(snapshot)
+        return self.responses.pop(0)
+
+
+class Ticker(SimpleNamespace):
+    pass
+
+
+def test_get_price_realtime_only():
+    ib = FakeIB([Ticker(last=100.0)])
+    price = asyncio.run(
+        get_price(ib, "AAPL", price_source="last", fallback_to_snapshot=True)
+    )
+    assert price == 100.0
+    assert ib.calls == [False]
+
+
+def test_get_price_uses_snapshot_when_missing():
+    ib = FakeIB([Ticker(last=None)], [Ticker(last=50.0)])
+    price = asyncio.run(
+        get_price(ib, "AAPL", price_source="last", fallback_to_snapshot=True)
+    )
+    assert price == 50.0
+    assert ib.calls == [False, True]
+
+
+def test_get_price_raises_when_unavailable():
+    ib = FakeIB([Ticker(last=None)])
+    with pytest.raises(PricingError):
+        asyncio.run(
+            get_price(ib, "AAPL", price_source="last", fallback_to_snapshot=False)
+        )
+    assert ib.calls == [False]


### PR DESCRIPTION
## Summary
- introduce `PricingError` and async `get_price` helper
- support snapshot fallback when realtime price missing
- add tests for realtime, snapshot and error scenarios

## Testing
- `pytest -q` (fails: Failed to connect to IBKR)
- `pytest -q -m 'not integration'`


------
https://chatgpt.com/codex/tasks/task_e_68b76aa989fc8320946788fd0f487666