### PR TITLE
Expose pricing utilities in core package

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core package exports."""
+
+# Re-export public pricing utilities for convenient access from ``core``.
+from .pricing import PricingError, get_price
+
+__all__ = ["get_price", "PricingError"]


### PR DESCRIPTION
## Summary
- export `get_price` and `PricingError` from `core`

## Testing
- `pre-commit run --files src/core/__init__.py`
- `pytest -q` *(fails: IBKRError: Failed to connect to IBKR)*

------
https://chatgpt.com/codex/tasks/task_e_68b76b3ef9948320ba6585ca50dd5da4