### PR TITLE
docs: mark pricing utility implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ python -m src.snapshot --config config/settings.ini
 This step requires an IBKR paper account and serves as a manual integration test.
 It returns positions and cash in USD, ignoring any CAD cash.
 
+### Pricing utility
+Retrieve a market price using [`src/core/pricing.py`](src/core/pricing.py):
+
+```python
+from src.core.pricing import get_price
+# assume `ib` is a connected ib_async.IB instance
+price = await get_price(ib, "SPY", price_source="last", fallback_to_snapshot=True)
+```
+
 ### Dry run
 ```bash
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv

--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -61,9 +61,9 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 ## Milestone C — Core Logic & Preview
 
 ### Phase C0 — Pricing Utility
-- [ ] `src/core/pricing.py` implemented
-- [ ] Honors `price_source` and `fallback_to_snapshot`
-- [ ] Unit tests for price retrieval and snapshot fallback
+- [x] `src/core/pricing.py` implemented
+- [x] Honors `price_source` and `fallback_to_snapshot`
+- [x] Unit tests for price retrieval and snapshot fallback
 
 ### Phase C1 — Model Mixing & Target Builder
 - [ ] `src/core/targets.py` implemented

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -123,6 +123,7 @@
 ### Milestone C — Core Logic & Preview
 
 #### Phase C0: Pricing utility
+_Status: Implemented in [`src/core/pricing.py`](../src/core/pricing.py)._
 **Deliverables**
 - `src/core/pricing.py` retrieves market prices for symbols
 - Honors `price_source` and optional `fallback_to_snapshot`

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -300,7 +300,7 @@ def load_config(path: str):
 
 ### C0. Pricing utility
 
-**Implement** `src/core/pricing.py`
+`src/core/pricing.py` implemented.
 - Fetch latest prices based on `price_source`
 - If real-time price missing and `fallback_to_snapshot=true`, use snapshot values
 - Wire into pipeline after snapshot retrieval and before drift/sizing calculations


### PR DESCRIPTION
## Summary
- mark pricing utility phase complete in dev plan
- document implemented pricing utility in plan and workflow
- add README snippet showing how to fetch prices

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: Failed to connect to IBKR)*
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b76d249fe48320889fa04057ab2ef6