### PR TITLE
feat: compute target weights

### DIFF
--- a/src/core/targets.py
+++ b/src/core/targets.py
@@ -1,4 +1,63 @@
-# Placeholder targets module
-def build_targets(models, mix):
-    # TODO: implement vector combination
-    return {}
+"""Portfolio target weight calculations.
+
+This module combines multiple model portfolios into a single set of target
+weights based on a user supplied mix.  The mix determines the overall
+contribution of each model to the final allocation.
+"""
+
+from __future__ import annotations
+
+from math import isclose
+
+from ..io.config_loader import Models
+
+
+class TargetError(ValueError):
+    """Raised when generated target weights are invalid."""
+
+
+def build_targets(
+    models: dict[str, dict[str, float]],
+    mix: Models,
+) -> dict[str, float]:
+    """Combine model portfolios according to ``mix``.
+
+    Parameters
+    ----------
+    models:
+        Mapping of symbols to per-model weights expressed in percent.  Each
+        inner mapping may omit some model keys; missing weights are treated as
+        ``0.0``.
+    mix:
+        Relative weighting of the individual models.  The ``smurf``,
+        ``badass`` and ``gltr`` fields should sum to ``1.0``.
+
+    Returns
+    -------
+    dict[str, float]
+        Final target weights in percent for each symbol.  ``CASH`` is included
+        when present in the input ``models`` mapping.
+
+    Raises
+    ------
+    TargetError
+        If the resulting weights do not sum to approximately ``100`` percent.
+    """
+
+    targets: dict[str, float] = {}
+    for symbol, wt in models.items():
+        weight = (
+            mix.smurf * wt.get("smurf", 0.0)
+            + mix.badass * wt.get("badass", 0.0)
+            + mix.gltr * wt.get("gltr", 0.0)
+        )
+        targets[symbol] = weight
+
+    total = sum(targets.values())
+    if not isclose(total, 100.0, abs_tol=0.01):
+        raise TargetError(f"target weights sum to {total:.2f}%, expected 100%")
+
+    return targets
+
+
+__all__ = ["TargetError", "build_targets"]

--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -1,0 +1,34 @@
+"""Tests for the :mod:`core.targets` module."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core.targets import TargetError, build_targets
+from src.io.config_loader import Models
+
+
+def test_build_targets_combines_models() -> None:
+    models = {
+        "AAA": {"smurf": 50.0, "badass": 0.0, "gltr": 100.0},
+        "BBB": {"smurf": 50.0, "badass": 100.0, "gltr": 0.0},
+        "CASH": {"smurf": 0.0, "badass": 0.0, "gltr": 0.0},
+    }
+    mix = Models(smurf=0.5, badass=0.25, gltr=0.25)
+    targets = build_targets(models, mix)
+
+    assert targets["AAA"] == pytest.approx(50.0)
+    assert targets["BBB"] == pytest.approx(50.0)
+    assert "CASH" in targets
+    assert sum(targets.values()) == pytest.approx(100.0)
+
+
+def test_build_targets_invalid_total() -> None:
+    models = {"AAA": {"smurf": 50.0, "badass": 50.0, "gltr": 50.0}}
+    mix = Models(smurf=0.5, badass=0.5, gltr=0.0)
+
+    with pytest.raises(TargetError):
+        build_targets(models, mix)


### PR DESCRIPTION
## Summary
- implement `build_targets` to combine model portfolios with mix weights
- raise `TargetError` when target weights deviate from 100%
- add unit tests for target weight calculation

## Testing
- `pre-commit run --files src/core/targets.py tests/unit/test_targets.py`
- `pytest` *(fails: IBKRError: Failed to connect to IBKR)*

------
https://chatgpt.com/codex/tasks/task_e_68b76fa6fd248320bc5813cb3c4303b6