### PR TITLE
Lazily re-export target utilities in core package

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -3,7 +3,14 @@
 # Re-export public pricing utilities for convenient access from ``core``.
 from .pricing import PricingError, get_price
 
-# Re-export target building utilities for convenient access from ``core``.
-from .targets import TargetError, build_targets
+# Lazy re-export target building utilities for convenient access from ``core``.
 
 __all__ = ["get_price", "PricingError", "build_targets", "TargetError"]
+
+
+def __getattr__(name: str):
+    if name in {"build_targets", "TargetError"}:
+        from . import targets
+
+        return getattr(targets, name)
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- stop importing target utilities at import time
- lazily load build_targets and TargetError via __getattr__

## Testing
- `pre-commit run --files src/core/__init__.py`
- `pytest` *(fails: Failed to connect to IBKR)*
- `pytest -k 'not ibkr_snapshot'`


------
https://chatgpt.com/codex/tasks/task_e_68b77645eb4483209c4b492f4e9dc7c9