### PR TITLE
Add CLI entry point for computing portfolio targets

### DIFF
--- a/src/core/targets.py
+++ b/src/core/targets.py
@@ -7,9 +7,12 @@ contribution of each model to the final allocation.
 
 from __future__ import annotations
 
+import argparse
+from pathlib import Path
 from math import isclose
 
 from ..io.config_loader import Models
+from ..io import load_config, load_portfolios
 
 
 class TargetError(ValueError):
@@ -60,4 +63,23 @@ def build_targets(
     return targets
 
 
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--csv", type=Path, required=True)
+    ns = parser.parse_args(argv)
+
+    cfg = load_config(ns.config)
+    models = load_portfolios(
+        ns.csv, host=cfg.ibkr.host, port=cfg.ibkr.port, client_id=cfg.ibkr.client_id
+    )
+    targets = build_targets(models, cfg.models)
+    for symbol, pct in sorted(targets.items()):
+        print(f"{symbol} {pct:.1f}%")
+
+
 __all__ = ["TargetError", "build_targets"]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add argparse CLI to build targets from config and portfolios
- output sorted symbol allocations for inspection

## Testing
- `python -m src.core.targets --config config/settings.ini --csv data/portfolios.csv` *(fails: ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 4002))*
- `pytest` *(fails: src.broker.ibkr_client.IBKRError: Failed to connect to IBKR)*

------
https://chatgpt.com/codex/tasks/task_e_68b777494840832085570189cb4bda6a