### PR TITLE
Sort imports in targets module

### DIFF
--- a/src/core/targets.py
+++ b/src/core/targets.py
@@ -8,11 +8,11 @@ contribution of each model to the final allocation.
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 from math import isclose
+from pathlib import Path
 
-from ..io.config_loader import Models
 from ..io import load_config, load_portfolios
+from ..io.config_loader import Models
 
 
 class TargetError(ValueError):


### PR DESCRIPTION
## Summary
- reorder core targets imports per isort

## Testing
- `isort --check-only src/core/targets.py -v`
- `ruff check .`
- `black --check .`
- `pytest` *(fails: IBKRError: Failed to connect to IBKR)*

------
https://chatgpt.com/codex/tasks/task_e_68b778b659b08320a4ebbd0c941e821c