### PR TITLE
Implement portfolio drift calculation

### DIFF
--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -1,4 +1,125 @@
-# Placeholder drift module
-def compute_drift(current, targets):
-    # TODO: implement drift logic
-    return []
+"""Portfolio drift calculations.
+
+This module compares the current portfolio allocation against target weights
+and reports the difference both in percent and dollar terms.  The resulting
+records drive later sizing and execution logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class Drift:
+    """Represents drift for a single symbol.
+
+    Attributes
+    ----------
+    symbol:
+        Ticker symbol or ``"CASH"`` for cash balances.
+    target_wt_pct:
+        Desired portfolio weight in percent.
+    current_wt_pct:
+        Current portfolio weight in percent.
+    drift_pct:
+        Difference between current and target weights (``current-target``).
+    drift_usd:
+        Dollar value of the drift.  Positive values indicate an overweight
+        position (requiring a sell to rebalance) while negative values indicate
+        an underweight position (requiring a buy).
+    action:
+        Suggested action: ``"BUY"`` when underweight, ``"SELL"`` when
+        overweight and ``"HOLD"`` when within the target.
+    """
+
+    symbol: str
+    target_wt_pct: float
+    current_wt_pct: float
+    drift_pct: float
+    drift_usd: float
+    action: str
+
+
+def compute_drift(
+    current: Mapping[str, float],
+    targets: Mapping[str, float],
+    prices: Mapping[str, float],
+    net_liq: float,
+    cfg: Any,
+) -> list[Drift]:
+    """Compute portfolio drift records.
+
+    Parameters
+    ----------
+    current:
+        Mapping of symbols to share quantities.  ``"CASH"`` represents the
+        dollar value of cash holdings.
+    targets:
+        Target weights in percent for each symbol.
+    prices:
+        Mapping of symbols to current market prices.  ``"CASH"`` is implicitly
+        priced at ``1``.
+    net_liq:
+        Net liquidation value of the portfolio in USD.
+    cfg:
+        Configuration object (unused but accepted for future expansion).
+
+    Returns
+    -------
+    list[Drift]
+        One :class:`Drift` record per symbol present in either ``current`` or
+        ``targets``.  The list is sorted alphabetically by symbol to ensure
+        deterministic output.
+    """
+
+    # Determine current weights for all held symbols.
+    values: dict[str, float] = {}
+    for symbol, qty in current.items():
+        if symbol == "CASH":
+            value = qty
+        else:
+            try:
+                price = prices[symbol]
+            except KeyError as exc:  # pragma: no cover - defensive programming
+                raise KeyError(f"missing price for {symbol}") from exc
+            value = qty * price
+        values[symbol] = value
+
+    current_wts = {
+        sym: (val / net_liq * 100.0 if net_liq else 0.0) for sym, val in values.items()
+    }
+
+    # Union of all symbols from current holdings and targets.
+    symbols = set(current_wts) | set(targets)
+
+    drifts: list[Drift] = []
+    for symbol in sorted(symbols):
+        target = targets.get(symbol, 0.0)
+        current_wt = current_wts.get(symbol, 0.0)
+        drift_pct = current_wt - target
+        drift_usd = net_liq * drift_pct / 100.0
+
+        if drift_pct > 0:
+            action = "SELL"
+        elif drift_pct < 0:
+            action = "BUY"
+        else:
+            action = "HOLD"
+
+        drifts.append(
+            Drift(
+                symbol=symbol,
+                target_wt_pct=target,
+                current_wt_pct=current_wt,
+                drift_pct=drift_pct,
+                drift_usd=drift_usd,
+                action=action,
+            )
+        )
+
+    return drifts
+
+
+__all__ = ["Drift", "compute_drift"]

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -1,0 +1,75 @@
+"""Tests for :mod:`core.drift` compute_drift function."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core.drift import compute_drift
+
+
+def test_compute_drift_normalizes_and_combines_targets() -> None:
+    """Drift uses prices and net liquidation to compute weight percentages."""
+
+    current = {"AAA": 10, "CASH": 5000}
+    targets = {"AAA": 50.0, "BBB": 50.0, "CASH": 0.0}
+    prices = {"AAA": 100.0, "BBB": 100.0}
+    net_liq = 6000.0  # 10*100 + 5000
+
+    drifts = compute_drift(current, targets, prices, net_liq, cfg=None)
+    by_symbol = {d.symbol: d for d in drifts}
+
+    assert len(drifts) == 3
+
+    aaa = by_symbol["AAA"]
+    assert aaa.target_wt_pct == pytest.approx(50.0)
+    assert aaa.current_wt_pct == pytest.approx(16.6667, rel=1e-4)
+    assert aaa.drift_pct == pytest.approx(-33.3333, rel=1e-4)
+    assert aaa.drift_usd == pytest.approx(-2000.0)
+    assert aaa.action == "BUY"
+
+    bbb = by_symbol["BBB"]
+    assert bbb.current_wt_pct == pytest.approx(0.0)
+    assert bbb.target_wt_pct == pytest.approx(50.0)
+    assert bbb.drift_pct == pytest.approx(-50.0)
+    assert bbb.drift_usd == pytest.approx(-3000.0)
+    assert bbb.action == "BUY"
+
+    cash = by_symbol["CASH"]
+    assert cash.current_wt_pct == pytest.approx(83.3333, rel=1e-4)
+    assert cash.target_wt_pct == pytest.approx(0.0)
+    assert cash.drift_pct == pytest.approx(83.3333, rel=1e-4)
+    assert cash.drift_usd == pytest.approx(5000.0)
+    assert cash.action == "SELL"
+
+
+def test_compute_drift_defaults_missing_targets_to_zero() -> None:
+    """Symbols absent from targets are treated as having 0% target weight."""
+
+    current = {"AAA": 5, "CCC": 10, "CASH": 0}
+    targets = {"AAA": 60.0, "BBB": 40.0}
+    prices = {"AAA": 100.0, "CCC": 10.0, "BBB": 100.0}
+    net_liq = 600.0  # 5*100 + 10*10
+
+    drifts = compute_drift(current, targets, prices, net_liq, cfg=None)
+    by_symbol = {d.symbol: d for d in drifts}
+
+    # Ensure "CCC" (missing from targets) defaults to 0 target weight
+    ccc = by_symbol["CCC"]
+    assert ccc.target_wt_pct == pytest.approx(0.0)
+    assert ccc.current_wt_pct == pytest.approx(16.6667, rel=1e-4)
+    assert ccc.drift_pct == pytest.approx(16.6667, rel=1e-4)
+    assert ccc.drift_usd == pytest.approx(100.0)
+    assert ccc.action == "SELL"
+
+    # "BBB" (missing from current) is treated as 0 current weight
+    bbb = by_symbol["BBB"]
+    assert bbb.current_wt_pct == pytest.approx(0.0)
+    assert bbb.target_wt_pct == pytest.approx(40.0)
+    assert bbb.drift_pct == pytest.approx(-40.0)
+    assert bbb.drift_usd == pytest.approx(-240.0)
+    assert bbb.action == "BUY"


### PR DESCRIPTION
## Summary
- add `Drift` dataclass for per-symbol drift details
- compute drift against targets using prices and net liquidation value
- cover drift logic with unit tests

## Testing
- `ruff check src/core/drift.py tests/unit/test_drift.py`
- `black src/core/drift.py tests/unit/test_drift.py`
- `pytest tests/unit/test_drift.py`
- `pytest` *(fails: Failed to connect to IBKR)*

------
https://chatgpt.com/codex/tasks/task_e_68b77a990bc08320b31e9df029279aaf