### PR TITLE
Add drift prioritization helper

### DIFF
--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -150,4 +150,30 @@ def compute_drift(
     return drifts
 
 
-__all__ = ["Drift", "compute_drift"]
+def prioritize_by_drift(drifts: list[Drift], cfg: Any) -> list[Drift]:
+    """Filter and sort drifts by dollar magnitude.
+
+    Parameters
+    ----------
+    drifts:
+        Drift records to evaluate.
+    cfg:
+        Configuration with ``rebalance.min_order_usd``.
+
+    Returns
+    -------
+    list[Drift]
+        Drifts whose absolute dollar value exceeds ``min_order_usd``,
+        sorted from largest to smallest by absolute drift.
+    """
+
+    try:
+        min_order = cfg.rebalance.min_order_usd  # type: ignore[attr-defined]
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise AttributeError("cfg.rebalance.min_order_usd is required") from exc
+
+    filtered = [d for d in drifts if abs(d.drift_usd) >= min_order]
+    return sorted(filtered, key=lambda d: abs(d.drift_usd), reverse=True)
+
+
+__all__ = ["Drift", "compute_drift", "prioritize_by_drift"]

--- a/tests/unit/test_prioritize.py
+++ b/tests/unit/test_prioritize.py
@@ -1,0 +1,36 @@
+"""Tests for drift prioritization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.core.drift import Drift, prioritize_by_drift
+
+
+def _cfg(min_usd: int) -> SimpleNamespace:
+    return SimpleNamespace(rebalance=SimpleNamespace(min_order_usd=min_usd))
+
+
+def test_prioritize_filters_and_sorts_by_abs_drift_usd() -> None:
+    drifts = [
+        Drift("AAA", 0.0, 0.0, 0.0, -120.0, "BUY"),
+        Drift("BBB", 0.0, 0.0, 0.0, 80.0, "SELL"),
+        Drift("CCC", 0.0, 0.0, 0.0, 200.0, "SELL"),
+    ]
+    cfg = _cfg(100)
+
+    prioritized = prioritize_by_drift(drifts, cfg)
+
+    assert [d.symbol for d in prioritized] == ["CCC", "AAA"]
+
+
+def test_prioritize_retains_all_when_threshold_zero() -> None:
+    drifts = [
+        Drift("AAA", 0.0, 0.0, 0.0, -120.0, "BUY"),
+        Drift("BBB", 0.0, 0.0, 0.0, 80.0, "SELL"),
+    ]
+    cfg = _cfg(0)
+
+    prioritized = prioritize_by_drift(drifts, cfg)
+
+    assert [d.symbol for d in prioritized] == ["AAA", "BBB"]


### PR DESCRIPTION
## Summary
- add `prioritize_by_drift` to filter and order rebalance candidates by dollar drift
- cover prioritization logic with unit tests

## Testing
- `pre-commit run --files src/core/drift.py tests/unit/test_prioritize.py`
- `pytest` *(fails: Failed to connect to IBKR)*
- `pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68b77ca4a2808320a2e36a79248e0776