### PR TITLE
feat: export drift utilities

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -2,10 +2,18 @@
 
 # Re-export public pricing utilities for convenient access from ``core``.
 from .pricing import PricingError, get_price
+from .drift import Drift, compute_drift
 
 # Lazy re-export target building utilities for convenient access from ``core``.
 
-__all__ = ["get_price", "PricingError", "build_targets", "TargetError"]
+__all__ = [
+    "get_price",
+    "PricingError",
+    "compute_drift",
+    "Drift",
+    "build_targets",
+    "TargetError",
+]
 
 
 def __getattr__(name: str):


### PR DESCRIPTION
## Summary
- expose `compute_drift` and `Drift` through the `core` package for easier imports

## Testing
- `pytest -q` *(fails: ConfigError invalid literal for int()...)*

------
https://chatgpt.com/codex/tasks/task_e_68b77d980d708320ae480cb8e6ea75d5