### PR TITLE
Add drift prioritization tests and config cleanup

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -1,36 +1,61 @@
 [ibkr]
-host = 127.0.0.1      ; Hostname or IP for IBKR Gateway/TWS (e.g., 127.0.0.1)
-port = 4002            ; Gateway/TWS port (4002 paper, 4001 live)
-client_id = 42         ; Unique API client ID (non-negative integer)
-account_id = DUA071544 ; IBKR account ID (U123456 live or DU123456 paper)
-read_only = false       ; true blocks trading, false enables order placement
+; Hostname or IP for IBKR Gateway/TWS (e.g., 127.0.0.1)
+host = 127.0.0.1
+; Gateway/TWS port (4002 paper, 4001 live)
+port = 4002
+; Unique API client ID (non-negative integer)
+client_id = 42
+; IBKR account ID (U123456 live or DU123456 paper)
+account_id = DUA071544
+; true blocks trading, false enables order placement
+read_only = false
 
 [models]
-smurf = 0.50 ; Weight for SMURF model (0-1, weights must sum to 1.0)
-badass = 0.30 ; Weight for BADASS model (0-1, weights must sum to 1.0)
-gltr  = 0.20 ; Weight for GLTR model (0-1, weights must sum to 1.0)
+; Weight for SMURF model (0-1, weights must sum to 1.0)
+smurf = 0.50
+; Weight for BADASS model (0-1, weights must sum to 1.0)
+badass = 0.30
+; Weight for GLTR model (0-1, weights must sum to 1.0)
+gltr  = 0.20
 
 [rebalance]
-trigger_mode = per_holding        ; per_holding | total_drift
-per_holding_band_bps = 50         ; Trade if |drift| > this bps (e.g., 50)
-portfolio_total_band_bps = 100    ; Used when trigger_mode=total_drift
-min_order_usd = 50                ; Ignore trades below this USD amount
-cash_buffer_pct = 1.0             ; Reserve this % of NetLiq as cash
-allow_fractional = false          ; true allows fractional shares
-max_leverage = 1.50               ; Max gross exposure multiple (e.g., 1.5 = 150%)
-maintenance_buffer_pct = 10       ; Placeholder maintenance margin buffer (not enforced)
-prefer_rth = true                 ; true trades only during regular trading hours
+; per_holding | total_drift
+trigger_mode = per_holding
+; Trade if |drift| > this bps (e.g., 50)
+per_holding_band_bps = 50
+; Used when trigger_mode=total_drift
+portfolio_total_band_bps = 100
+; Ignore trades below this USD amount
+min_order_usd = 50
+; Reserve this % of NetLiq as cash
+cash_buffer_pct = 1.0
+; true allows fractional shares
+allow_fractional = false
+; Max gross exposure multiple (e.g., 1.5 = 150%)
+max_leverage = 1.50
+; Placeholder maintenance margin buffer (not enforced)
+maintenance_buffer_pct = 10
+; true trades only during regular trading hours
+prefer_rth = true
 
 [pricing]
-price_source = last               ; Price field: last | close | bid | ask
-fallback_to_snapshot = true       ; true retries with delayed snapshot if needed
+; Price field: last | close | bid | ask
+price_source = last
+; true retries with delayed snapshot if needed
+fallback_to_snapshot = true
 
 [execution]
-order_type = market               ; Order type (market only)
-algo_preference = adaptive        ; Preferred algo: adaptive | midprice
-fallback_plain_market = true      ; true falls back to plain market if algo fails
-batch_orders = true               ; true submits orders in batches
+; Order type (market only)
+order_type = market
+; Preferred algo: adaptive | midprice
+algo_preference = adaptive
+; true falls back to plain market if algo fails
+fallback_plain_market = true
+; true submits orders in batches
+batch_orders = true
 
 [io]
-report_dir = reports              ; Directory for CSV reports and logs
-log_level = INFO                  ; Logging level: DEBUG | INFO | WARNING | ERROR | CRITICAL
+; Directory for CSV reports and logs
+report_dir = reports
+; Logging level: DEBUG | INFO | WARNING | ERROR | CRITICAL
+log_level = INFO

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: marks tests that require external IBKR connection (deselect with '-m "not integration"')
+addopts = -m "not integration"


### PR DESCRIPTION
## Summary
- add fixtures and tests for per_holding and total_drift triggers
- test prioritize_by_drift filtering and sorting
- sanitize settings.ini and skip integration tests by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77e4fdadc8320887bdc5ce9565d5b