### PR TITLE
Format test_drift with Black

### DIFF
--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -127,7 +127,9 @@ def test_per_holding_mode_triggers_symbols_and_skips_small_drifts(
     cfg_factory,
 ) -> None:
     cfg = cfg_factory("per_holding", per_band=300)
-    drifts = compute_drift(per_holding_current, per_holding_targets, sample_prices, 100.0, cfg)
+    drifts = compute_drift(
+        per_holding_current, per_holding_targets, sample_prices, 100.0, cfg
+    )
     symbols = [d.symbol for d in drifts]
     assert symbols == ["AAA", "BBB"]
     by_symbol = {d.symbol: d for d in drifts}


### PR DESCRIPTION
## Summary
- format compute_drift call in test_per_holding_mode_triggers_symbols_and_skips_small_drifts

## Testing
- `black --check tests/unit/test_drift.py`
- `pytest tests/unit/test_drift.py`


------
https://chatgpt.com/codex/tasks/task_e_68b78028e5fc8320a549dd3fb3b68ca1