### PR TITLE
Add src directory to pytest pythonpath

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     integration: marks tests that require external IBKR connection (deselect with '-m "not integration"')
 addopts = -m "not integration"
+pythonpath = src


### PR DESCRIPTION
## Summary
- include `src` in pytest's pythonpath so tests can import project modules

## Testing
- `pytest tests/unit/test_prioritize.py::test_prioritize_filters_and_sorts_by_abs_drift_usd -q`

------
https://chatgpt.com/codex/tasks/task_e_68b78299e0008320beb03178b3414331