### PR TITLE
Add drift preview rendering and integrate into rebalance scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ from src.core.pricing import get_price
 price = await get_price(ib, "SPY", price_source="last", fallback_to_snapshot=True)
 ```
 
+### Drift preview
+Generate a table of drift metrics:
+
+```bash
+python -m src.core.preview
+```
+
 ### Dry run
 ```bash
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv

--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -1,4 +1,60 @@
-# Placeholder preview renderer
-def render(plan):
-    # TODO: pretty table and batch summary
-    return "<preview here>"
+"""Render a drift preview table.
+
+This module formats a list of :class:`~src.core.drift.Drift` records into a
+human readable table.  It is intentionally presentation only and performs no
+side effects beyond returning the rendered string.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.table import Table
+
+from .drift import Drift
+
+
+def render(plan: list[Drift]) -> str:
+    """Return a formatted table for the given drift plan.
+
+    Parameters
+    ----------
+    plan:
+        Drift records, typically already filtered and prioritised.
+
+    Returns
+    -------
+    str
+        Table rendering of the drift information.
+    """
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Symbol")
+    table.add_column("Target %", justify="right")
+    table.add_column("Current %", justify="right")
+    table.add_column("Drift %", justify="right")
+    table.add_column("Drift $", justify="right")
+    table.add_column("Action")
+
+    for d in plan:
+        table.add_row(
+            d.symbol,
+            f"{d.target_wt_pct:.2f}",
+            f"{d.current_wt_pct:.2f}",
+            f"{d.drift_pct:.2f}",
+            f"{d.drift_usd:.2f}",
+            d.action,
+        )
+
+    from io import StringIO
+
+    console = Console(file=StringIO(), record=True)
+    console.print(table)
+    return console.export_text()
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience demo
+    sample_plan = [
+        Drift("AAA", 50.0, 60.0, 10.0, 640.0, "SELL"),
+        Drift("BBB", 50.0, 40.0, -10.0, -640.0, "BUY"),
+    ]
+    print(render(sample_plan))

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -1,7 +1,11 @@
 import argparse
 from pathlib import Path
+from types import SimpleNamespace
 
 from rich import print
+
+from src.core.drift import compute_drift, prioritize_by_drift
+from src.core.preview import render as render_preview
 
 
 def main():
@@ -17,13 +21,22 @@ def main():
         print("[yellow]Read-only is enabled; trading will be blocked.[/yellow]")
 
     # Placeholder flow
-    cfg = Path(args.config)
-    csv = Path(args.csv)
-    print(f"[bold]Loaded[/bold] config: {cfg.resolve()}")
-    print(f"[bold]Loaded[/bold] portfolios: {csv.resolve()}")
-    print(
-        "[cyan]Preview would be generated here (drift %, drift $, sizing, leverage).[/cyan]"
-    )
+    cfg_path = Path(args.config)
+    csv_path = Path(args.csv)
+    print(f"[bold]Loaded[/bold] config: {cfg_path.resolve()}")
+    print(f"[bold]Loaded[/bold] portfolios: {csv_path.resolve()}")
+
+    # Placeholder portfolio data
+    cfg = SimpleNamespace(rebalance=SimpleNamespace(min_order_usd=100))
+    current = {"AAA": 10, "BBB": 5, "CASH": 5000}
+    targets = {"AAA": 50.0, "BBB": 50.0}
+    prices = {"AAA": 100.0, "BBB": 80.0}
+    net_liq = 10 * 100.0 + 5 * 80.0 + 5000
+
+    drifts = compute_drift(current, targets, prices, net_liq, cfg)
+    prioritized = prioritize_by_drift(drifts, cfg)
+    table = render_preview(prioritized)
+    print(table)
     if args.dry_run:
         print("[green]Dry run complete (no orders submitted).[/green]")
         return

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,0 +1,27 @@
+"""Tests for the preview renderer."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.core.drift import Drift, prioritize_by_drift
+from src.core.preview import render
+
+
+def _cfg(min_usd: int) -> SimpleNamespace:
+    return SimpleNamespace(rebalance=SimpleNamespace(min_order_usd=min_usd))
+
+
+def test_render_sorted_and_filtered() -> None:
+    drifts = [
+        Drift("AAA", 0.0, 0.0, 0.0, -120.0, "BUY"),
+        Drift("BBB", 0.0, 0.0, 0.0, 80.0, "SELL"),
+        Drift("CCC", 0.0, 0.0, 0.0, 200.0, "SELL"),
+    ]
+    cfg = _cfg(100)
+
+    prioritized = prioritize_by_drift(drifts, cfg)
+    table = render(prioritized)
+
+    assert "BBB" not in table
+    assert table.index("CCC") < table.index("AAA")


### PR DESCRIPTION
## Summary
- render drift records as a formatted table
- call compute_drift and prioritize_by_drift in rebalance scaffold and show table
- document preview command
- add unit test for preview rendering order and filtering

## Testing
- `pre-commit run --files src/core/preview.py src/rebalance.py README.md tests/unit/test_preview.py`
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b783aa9ea483209930a46d164e68fa