### PR TITLE
Connect live data in rebalance preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $env:PYTHONPATH = "."
 pytest -q -m "not integration"
 ```
 
-## Usage (placeholders)
+## Usage
 
 ### Validate configuration
 ```bash
@@ -56,6 +56,8 @@ python -m src.core.preview
 ```
 
 ### Dry run
+Launch IB Gateway or Trader Workstation, then run:
+
 ```bash
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
 ```

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -1,37 +1,53 @@
+"""Rebalance CLI entry point."""
+
+from __future__ import annotations
+
 import argparse
+import asyncio
 from pathlib import Path
-from types import SimpleNamespace
 
 from rich import print
 
+from src.broker.ibkr_client import IBKRClient, IBKRError
 from src.core.drift import compute_drift, prioritize_by_drift
 from src.core.preview import render as render_preview
+from src.io.config_loader import ConfigError, load_config
+from src.io.portfolio_csv import PortfolioCSVError, load_portfolios
 
 
-def main():
-    parser = argparse.ArgumentParser(description="IBKR ETF Rebalancer (scaffold)")
-    parser.add_argument("--config", default="config/settings.ini")
-    parser.add_argument("--csv", default="data/portfolios.csv")
-    parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--confirm", action="store_true")
-    parser.add_argument("--read-only", action="store_true")
-    args = parser.parse_args()
-
-    if args.read_only and args.confirm:
-        print("[yellow]Read-only is enabled; trading will be blocked.[/yellow]")
-
-    # Placeholder flow
+async def _run(args: argparse.Namespace) -> None:
     cfg_path = Path(args.config)
     csv_path = Path(args.csv)
-    print(f"[bold]Loaded[/bold] config: {cfg_path.resolve()}")
-    print(f"[bold]Loaded[/bold] portfolios: {csv_path.resolve()}")
 
-    # Placeholder portfolio data
-    cfg = SimpleNamespace(rebalance=SimpleNamespace(min_order_usd=100))
-    current = {"AAA": 10, "BBB": 5, "CASH": 5000}
-    targets = {"AAA": 50.0, "BBB": 50.0}
-    prices = {"AAA": 100.0, "BBB": 80.0}
-    net_liq = 10 * 100.0 + 5 * 80.0 + 5000
+    cfg = load_config(cfg_path)
+    portfolios = load_portfolios(
+        csv_path,
+        host=cfg.ibkr.host,
+        port=cfg.ibkr.port,
+        client_id=cfg.ibkr.client_id,
+    )
+
+    client = IBKRClient()
+    await client.connect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
+    try:
+        snapshot = await client.snapshot(cfg.ibkr.account_id)
+    finally:
+        await client.disconnect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
+
+    current = {p["symbol"]: float(p["position"]) for p in snapshot["positions"]}
+    current["CASH"] = float(snapshot["cash"])
+    prices = {p["symbol"]: float(p["avg_cost"]) for p in snapshot["positions"]}
+    net_liq = snapshot["cash"] + sum(
+        prices[sym] * qty for sym, qty in current.items() if sym != "CASH"
+    )
+
+    targets: dict[str, float] = {}
+    for symbol, weights in portfolios.items():
+        targets[symbol] = (
+            weights["smurf"] * cfg.models.smurf
+            + weights["badass"] * cfg.models.badass
+            + weights["gltr"] * cfg.models.gltr
+        )
 
     drifts = compute_drift(current, targets, prices, net_liq, cfg)
     prioritized = prioritize_by_drift(drifts, cfg)
@@ -50,9 +66,26 @@ def main():
         else:
             print("[yellow]Aborted by user.[/yellow]")
     else:
-        print(
-            "[yellow]No --confirm provided; exiting after preview placeholder.[/yellow]"
-        )
+        print("[yellow]No --confirm provided; exiting after preview.[/yellow]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="IBKR ETF Rebalancer (scaffold)")
+    parser.add_argument("--config", default="config/settings.ini")
+    parser.add_argument("--csv", default="data/portfolios.csv")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--confirm", action="store_true")
+    parser.add_argument("--read-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.read_only and args.confirm:
+        print("[yellow]Read-only is enabled; trading will be blocked.[/yellow]")
+
+    try:
+        asyncio.run(_run(args))
+    except (ConfigError, PortfolioCSVError, IBKRError) as exc:
+        print(f"[red]{exc}[/red]")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Load config and portfolios, connect to IBKR and build current holdings, prices and net liq
- Compute drift from real positions and render preview
- Document launching Gateway before running rebalance

## Testing
- `pre-commit run --files src/rebalance.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78673c9408320987c52ca33e84bf3