### PR TITLE
refactor: make portfolio loading async

### DIFF
--- a/src/core/targets.py
+++ b/src/core/targets.py
@@ -8,6 +8,7 @@ contribution of each model to the final allocation.
 from __future__ import annotations
 
 import argparse
+import asyncio
 from math import isclose
 from pathlib import Path
 
@@ -63,14 +64,14 @@ def build_targets(
     return targets
 
 
-def main(argv=None):
+async def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=Path, required=True)
     parser.add_argument("--csv", type=Path, required=True)
     ns = parser.parse_args(argv)
 
     cfg = load_config(ns.config)
-    models = load_portfolios(
+    models = await load_portfolios(
         ns.csv, host=cfg.ibkr.host, port=cfg.ibkr.port, client_id=cfg.ibkr.client_id
     )
     targets = build_targets(models, cfg.models)
@@ -82,4 +83,4 @@ __all__ = ["TargetError", "build_targets"]
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -38,7 +38,7 @@ def _parse_percent(value: str, *, symbol: str, model: str) -> float:
     return pct
 
 
-def validate_symbols(
+async def validate_symbols(
     symbols: Iterable[str], *, host: str, port: int, client_id: int
 ) -> None:
     """Ensure ``symbols`` are valid USD-denominated ETFs.
@@ -62,9 +62,11 @@ def validate_symbols(
 
     ib = IB()
     try:
-        ib.connect(host, port, clientId=client_id)
+        await ib.connectAsync(host, port, clientId=client_id)
         for symbol in symbols_to_check:
-            details = ib.reqContractDetails(Stock(symbol=symbol, currency="USD"))
+            details = await ib.reqContractDetailsAsync(
+                Stock(symbol=symbol, currency="USD")
+            )
             if not details:
                 raise PortfolioCSVError(f"Unknown ETF symbol: {symbol}")
             cd = details[0]
@@ -85,7 +87,7 @@ def validate_symbols(
             ib.disconnect()
 
 
-def load_portfolios(
+async def load_portfolios(
     path: Path, *, host: str, port: int, client_id: int
 ) -> dict[str, dict[str, float]]:
     """Load portfolio model weights from ``path``.
@@ -130,7 +132,7 @@ def load_portfolios(
                 weights[model.lower()] = weight
             portfolios[symbol] = weights
 
-    validate_symbols(portfolios.keys(), host=host, port=port, client_id=client_id)
+    await validate_symbols(portfolios.keys(), host=host, port=port, client_id=client_id)
 
     totals = {"smurf": 0.0, "badass": 0.0, "gltr": 0.0}
     for symbol, weights in portfolios.items():

--- a/src/io/validate_portfolios.py
+++ b/src/io/validate_portfolios.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from .config_loader import ConfigError, load_config
 from .portfolio_csv import PortfolioCSVError, load_portfolios
 
 
-def main(path: str, *, config_path: str) -> None:
+async def main(path: str, *, config_path: str) -> None:
     """Validate and load ``path`` printing ``OK`` on success."""
 
     try:
@@ -18,7 +19,7 @@ def main(path: str, *, config_path: str) -> None:
         raise SystemExit(1)
 
     try:
-        load_portfolios(
+        await load_portfolios(
             Path(path),
             host=cfg.ibkr.host,
             port=cfg.ibkr.port,
@@ -37,4 +38,4 @@ if __name__ == "__main__":  # pragma: no cover - CLI utility
     parser.add_argument("csv_path", help="Portfolio CSV to validate")
     parser.add_argument("--config", required=True, help="Path to settings.ini")
     args = parser.parse_args()
-    main(args.csv_path, config_path=args.config)
+    asyncio.run(main(args.csv_path, config_path=args.config))

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -20,7 +20,7 @@ async def _run(args: argparse.Namespace) -> None:
     csv_path = Path(args.csv)
 
     cfg = load_config(cfg_path)
-    portfolios = load_portfolios(
+    portfolios = await load_portfolios(
         csv_path,
         host=cfg.ibkr.host,
         port=cfg.ibkr.port,

--- a/tests/unit/test_validate_symbols.py
+++ b/tests/unit/test_validate_symbols.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from pathlib import Path
 
@@ -23,12 +24,14 @@ class FakeIB:
         self.calls: list[str] = []
         self.connected: bool = False
 
-    def reqContractDetails(self, contract):
+    async def reqContractDetailsAsync(self, contract):
         self.calls.append(contract.symbol)
         detail = self.mapping.get(contract.symbol)
         return [detail] if detail else []
 
-    def connect(self, host, port, clientId):  # noqa: N803 (upstream uses camelCase)
+    async def connectAsync(
+        self, host, port, clientId
+    ):  # noqa: N803 (upstream uses camelCase)
         self.connected = True
 
     def disconnect(self):
@@ -43,8 +46,10 @@ def setup_fake_ib(monkeypatch) -> FakeIB:
 
 def test_validate_symbols_valid(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
-    portfolio_csv.validate_symbols(
-        ["BLOK", "SPY"], host="127.0.0.1", port=4001, client_id=1
+    asyncio.run(
+        portfolio_csv.validate_symbols(
+            ["BLOK", "SPY"], host="127.0.0.1", port=4001, client_id=1
+        )
     )
     assert ib.calls == ["BLOK", "SPY"]
 
@@ -52,15 +57,19 @@ def test_validate_symbols_valid(monkeypatch) -> None:
 def test_validate_symbols_unknown(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
     with pytest.raises(PortfolioCSVError):
-        portfolio_csv.validate_symbols(
-            ["BLOK", "BAD"], host="127.0.0.1", port=4001, client_id=1
+        asyncio.run(
+            portfolio_csv.validate_symbols(
+                ["BLOK", "BAD"], host="127.0.0.1", port=4001, client_id=1
+            )
         )
     assert ib.calls == ["BLOK", "BAD"]
 
 
 def test_validate_symbols_skips_cash(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
-    portfolio_csv.validate_symbols(
-        ["CASH", "SPY"], host="127.0.0.1", port=4001, client_id=1
+    asyncio.run(
+        portfolio_csv.validate_symbols(
+            ["CASH", "SPY"], host="127.0.0.1", port=4001, client_id=1
+        )
     )
     assert ib.calls == ["SPY"]


### PR DESCRIPTION
## Summary
- make symbol validation and portfolio loading async
- update rebalance and validation CLI for async loading
- adjust tests to run async functions

## Testing
- `pre-commit run --files tests/unit/test_portfolio_csv.py tests/unit/test_validate_symbols.py src/io/validate_portfolios.py src/core/targets.py src/io/portfolio_csv.py src/rebalance.py`
- `pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68b788549f4c83209c071072ac47ec17