### PR TITLE
Implement greedy trade sizing with leverage checks

### DIFF
--- a/src/core/sizing.py
+++ b/src/core/sizing.py
@@ -1,4 +1,173 @@
-# Placeholder sizing module
-def size_orders(drift, config):
-    # TODO: implement sizing with leverage guard
-    return []
+"""Trade sizing logic.
+
+This module converts :class:`~src.core.drift.Drift` records into concrete trade
+sizes while enforcing cash buffers and leverage limits.  The algorithm works in
+two phases:
+
+* Greedily allocate capital to the highest priority drifts while respecting the
+  available cash after reserving a configurable buffer.
+* Compute the projected portfolio exposure and scale back the lowest priority
+  buy orders until the requested leverage does not exceed ``max_leverage``.
+
+It returns the final list of sized trades along with exposure information that
+can be used for preview purposes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from .drift import Drift
+
+
+@dataclass
+class SizedTrade:
+    """Concrete sized trade for a symbol."""
+
+    symbol: str
+    action: str  # ``"BUY"`` or ``"SELL"``
+    quantity: float
+    notional: float
+
+
+def _extract_cfg(cfg: Any) -> tuple[int, bool, float, float]:
+    """Return relevant rebalance configuration values."""
+
+    try:
+        reb = cfg.rebalance  # type: ignore[attr-defined]
+        return (
+            reb.min_order_usd,
+            reb.allow_fractional,
+            reb.cash_buffer_pct,
+            reb.max_leverage,
+        )
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise AttributeError("cfg.rebalance is missing required fields") from exc
+
+
+def _infer_net_liq(drifts: Iterable[Drift], cash: float) -> float:
+    """Infer ``net_liq`` from the provided drifts.
+
+    ``compute_drift`` derives all ``drift_usd`` values from a common net
+    liquidation figure.  We reverse that relationship here by taking the first
+    non-zero drift percentage.  When no such drift is available we fall back to
+    the cash balance which is a reasonable approximation for an empty
+    portfolio.
+    """
+
+    for d in drifts:
+        if d.drift_pct != 0:
+            return d.drift_usd * 100.0 / d.drift_pct
+    return cash
+
+
+def size_orders(
+    drifts: list[Drift],
+    prices: Mapping[str, float],
+    cash: float,
+    cfg: Any,
+) -> tuple[list[SizedTrade], float, float]:
+    """Size trades based on drift information.
+
+    Parameters
+    ----------
+    drifts:
+        Prioritised drift records.
+    prices:
+        Mapping of symbols to current prices.
+    cash:
+        Current cash balance in USD.
+    cfg:
+        Configuration object containing ``rebalance`` settings.
+
+    Returns
+    -------
+    tuple[list[SizedTrade], float, float]
+        A list of :class:`SizedTrade` objects along with the projected gross
+        exposure and leverage after applying the trades.
+    """
+
+    min_order_usd, allow_fractional, cash_buffer_pct, max_leverage = _extract_cfg(
+        cfg
+    )
+
+    net_liq = _infer_net_liq(drifts, cash)
+
+    reserve = net_liq * cash_buffer_pct
+    available = cash - reserve
+
+    trades: list[SizedTrade] = []
+    total_buy = 0.0
+    total_sell = 0.0
+
+    for d in drifts:
+        if d.symbol == "CASH":
+            continue
+        try:
+            price = prices[d.symbol]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"missing price for {d.symbol}") from exc
+
+        notional = abs(d.drift_usd)
+        if d.action == "BUY":
+            spend = min(notional, max(0.0, available))
+            if spend <= 0:
+                continue
+            qty = spend / price
+            if not allow_fractional:
+                qty = float(int(qty))
+                spend = qty * price
+            if spend < min_order_usd:
+                continue
+            trades.append(SizedTrade(d.symbol, "BUY", qty, spend))
+            available -= spend
+            total_buy += spend
+        elif d.action == "SELL":
+            qty = notional / price
+            if not allow_fractional:
+                qty = float(int(qty))
+                notional = qty * price
+            if notional < min_order_usd:
+                continue
+            trades.append(SizedTrade(d.symbol, "SELL", qty, notional))
+            available += notional
+            total_sell += notional
+
+    gross_exposure = (net_liq - cash) + total_buy - total_sell
+    leverage = gross_exposure / net_liq if net_liq else 0.0
+
+    if leverage > max_leverage and total_buy > 0:
+        excess = gross_exposure - max_leverage * net_liq
+        for trade in reversed(trades):
+            if trade.action != "BUY":
+                continue
+            if excess <= 0:
+                break
+
+            reduction = min(trade.notional, excess)
+            new_notional = trade.notional - reduction
+            price = prices[trade.symbol]
+            qty = new_notional / price
+            if not allow_fractional:
+                qty = float(int(qty))
+                new_notional = qty * price
+
+            if new_notional < min_order_usd or qty == 0:
+                excess -= trade.notional
+                total_buy -= trade.notional
+                trades.remove(trade)
+            else:
+                excess -= trade.notional - new_notional
+                total_buy -= trade.notional - new_notional
+                trade.quantity = qty
+                trade.notional = new_notional
+
+        gross_exposure = (net_liq - cash) + total_buy - total_sell
+        leverage = gross_exposure / net_liq if net_liq else 0.0
+
+    return trades, gross_exposure, leverage
+
+
+__all__ = ["SizedTrade", "size_orders"]
+

--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -1,0 +1,74 @@
+"""Tests for trade sizing logic."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.core.drift import Drift
+from src.core.sizing import SizedTrade, size_orders
+
+
+def _cfg(
+    *,
+    min_order_usd: int = 1,
+    allow_fractional: bool = False,
+    cash_buffer_pct: float = 0.0,
+    max_leverage: float = 1.0,
+):
+    reb = SimpleNamespace(
+        min_order_usd=min_order_usd,
+        allow_fractional=allow_fractional,
+        cash_buffer_pct=cash_buffer_pct,
+        max_leverage=max_leverage,
+    )
+    return SimpleNamespace(rebalance=reb)
+
+
+def _drift(symbol: str, usd: float, net_liq: float) -> Drift:
+    pct = usd / net_liq * 100.0
+    action = "BUY" if usd < 0 else "SELL" if usd > 0 else "HOLD"
+    # The specific target/current weights are irrelevant for sizing; they only
+    # need to differ by ``pct``.
+    current = 0.0
+    target = -pct
+    return Drift(symbol, target, current, pct, usd, action)
+
+
+def test_sizes_buy_respecting_cash_buffer_and_rounding() -> None:
+    net_liq = 1000.0
+    drifts = [_drift("AAA", -150.0, net_liq)]
+    prices = {"AAA": 10.0}
+    cfg = _cfg(cash_buffer_pct=0.1)  # reserve 100 USD
+
+    trades, gross, lev = size_orders(drifts, prices, cash=200.0, cfg=cfg)
+
+    assert trades == [SizedTrade("AAA", "BUY", 10.0, 100.0)]
+    assert gross == 900.0
+    assert lev == 0.9
+
+
+def test_drops_orders_below_min_after_rounding() -> None:
+    net_liq = 1000.0
+    drifts = [_drift("AAA", -80.0, net_liq)]
+    prices = {"AAA": 45.0}
+    cfg = _cfg(min_order_usd=50)
+
+    trades, gross, lev = size_orders(drifts, prices, cash=600.0, cfg=cfg)
+
+    assert trades == []
+    assert gross == 400.0  # exposure unchanged
+    assert lev == 0.4
+
+
+def test_scales_down_low_priority_buys_to_meet_leverage() -> None:
+    net_liq = 1000.0
+    drifts = [_drift("AAA", -100.0, net_liq), _drift("BBB", -100.0, net_liq)]
+    prices = {"AAA": 10.0, "BBB": 10.0}
+    cfg = _cfg(max_leverage=0.85)
+
+    trades, gross, lev = size_orders(drifts, prices, cash=200.0, cfg=cfg)
+
+    assert trades == [SizedTrade("AAA", "BUY", 5.0, 50.0)]
+    assert gross == 850.0
+    assert lev == 0.85
+


### PR DESCRIPTION
## Summary
- add `SizedTrade` dataclass and cash-buffered greedy sizing algorithm
- round quantities and drop small orders; enforce leverage cap by scaling down low-priority buys
- include unit tests for sizing logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78a8c2a688320ba4aa39b2d41cc4c