### PR TITLE
Expose order sizing utilities from core package

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -4,7 +4,7 @@
 from .drift import Drift, compute_drift
 from .pricing import PricingError, get_price
 
-# Lazy re-export target building utilities for convenient access from ``core``.
+# Lazy re-export additional utilities for convenient access from ``core``.
 
 __all__ = [
     "get_price",
@@ -13,6 +13,8 @@ __all__ = [
     "Drift",
     "build_targets",
     "TargetError",
+    "size_orders",
+    "SizedTrade",
 ]
 
 
@@ -21,4 +23,8 @@ def __getattr__(name: str):
         from . import targets
 
         return getattr(targets, name)
+    if name in {"size_orders", "SizedTrade"}:
+        from . import sizing
+
+        return getattr(sizing, name)
     raise AttributeError(name)

--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from src.core.drift import Drift
-from src.core.sizing import SizedTrade, size_orders
+from src.core import Drift, SizedTrade, size_orders
 
 
 def _cfg(


### PR DESCRIPTION
## Summary
- lazily re-export `size_orders` and `SizedTrade` from `core`.
- adjust tests to exercise new `core` import path.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78bf564d88320a442cb98958cd6aa