### PR TITLE
Add unit tests for order sizing logic

### DIFF
--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -1,10 +1,22 @@
-"""Tests for trade sizing logic."""
+"""Tests for sizing logic."""
 
-from __future__ import annotations
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
-from types import SimpleNamespace
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from src.core import Drift, SizedTrade, size_orders
+# ``src.__init__`` imports ``ib_async`` which isn't required for these tests.
+ib_async = ModuleType("ib_async")
+ib_async.IB = object
+contract_mod = ModuleType("ib_async.contract")
+contract_mod.Stock = object
+ib_async.contract = contract_mod
+sys.modules.setdefault("ib_async", ib_async)
+sys.modules.setdefault("ib_async.contract", contract_mod)
+
+from src.core.drift import Drift
+from src.core.sizing import SizedTrade, size_orders
 
 
 def _cfg(
@@ -33,33 +45,21 @@ def _drift(symbol: str, usd: float, net_liq: float) -> Drift:
     return Drift(symbol, target, current, pct, usd, action)
 
 
-def test_sizes_buy_respecting_cash_buffer_and_rounding() -> None:
+def test_greedy_fill_under_limited_cash() -> None:
     net_liq = 1000.0
-    drifts = [_drift("AAA", -150.0, net_liq)]
-    prices = {"AAA": 10.0}
-    cfg = _cfg(cash_buffer_pct=0.1)  # reserve 100 USD
+    drifts = [_drift("AAA", -150.0, net_liq), _drift("BBB", -100.0, net_liq)]
+    prices = {"AAA": 24.0, "BBB": 10.0}
+    cfg = _cfg(cash_buffer_pct=0.1, allow_fractional=True)
 
     trades, gross, lev = size_orders(drifts, prices, cash=200.0, cfg=cfg)
 
-    assert trades == [SizedTrade("AAA", "BUY", 10.0, 100.0)]
+    qty = 100.0 / prices["AAA"]  # all available cash goes to highest priority
+    assert trades == [SizedTrade("AAA", "BUY", qty, 100.0)]
     assert gross == 900.0
     assert lev == 0.9
 
 
-def test_drops_orders_below_min_after_rounding() -> None:
-    net_liq = 1000.0
-    drifts = [_drift("AAA", -80.0, net_liq)]
-    prices = {"AAA": 45.0}
-    cfg = _cfg(min_order_usd=50)
-
-    trades, gross, lev = size_orders(drifts, prices, cash=600.0, cfg=cfg)
-
-    assert trades == []
-    assert gross == 400.0  # exposure unchanged
-    assert lev == 0.4
-
-
-def test_scales_down_low_priority_buys_to_meet_leverage() -> None:
+def test_leverage_scaled_when_exceeding_max() -> None:
     net_liq = 1000.0
     drifts = [_drift("AAA", -100.0, net_liq), _drift("BBB", -100.0, net_liq)]
     prices = {"AAA": 10.0, "BBB": 10.0}
@@ -70,4 +70,17 @@ def test_scales_down_low_priority_buys_to_meet_leverage() -> None:
     assert trades == [SizedTrade("AAA", "BUY", 5.0, 50.0)]
     assert gross == 850.0
     assert lev == 0.85
+
+
+def test_rounds_and_drops_orders_below_min() -> None:
+    net_liq = 1000.0
+    drifts = [_drift("AAA", -80.0, net_liq)]
+    prices = {"AAA": 45.0}
+    cfg = _cfg(min_order_usd=50, allow_fractional=False)
+
+    trades, gross, lev = size_orders(drifts, prices, cash=600.0, cfg=cfg)
+
+    assert trades == []
+    assert gross == 400.0  # exposure unchanged
+    assert lev == 0.4
 


### PR DESCRIPTION
## Summary
- add sizing tests for greedy fills, leverage scaling and min-order rounding

## Testing
- `python3 -m pytest tests/unit/test_sizing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78c79c0f88320bb173053506e5a3c