### PR TITLE
silence ruff E402 in sizing tests

### DIFF
--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -15,8 +15,8 @@ ib_async.contract = contract_mod
 sys.modules.setdefault("ib_async", ib_async)
 sys.modules.setdefault("ib_async.contract", contract_mod)
 
-from src.core.drift import Drift
-from src.core.sizing import SizedTrade, size_orders
+from src.core.drift import Drift  # noqa: E402
+from src.core.sizing import SizedTrade, size_orders  # noqa: E402
 
 
 def _cfg(


### PR DESCRIPTION
## Summary
- silence ruff E402 in sizing tests by annotating late imports

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78e3b35688320a9bd212cb28e5b54