### PR TITLE
fix: silence mypy module attribute errors

### DIFF
--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -3,13 +3,15 @@
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Any
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 # ``src.__init__`` imports ``ib_async`` which isn't required for these tests.
-ib_async = ModuleType("ib_async")
+# The ``Any`` annotations silence mypy's attribute checks for these dummy modules.
+ib_async: Any = ModuleType("ib_async")
 ib_async.IB = object
-contract_mod = ModuleType("ib_async.contract")
+contract_mod: Any = ModuleType("ib_async.contract")
 contract_mod.Stock = object
 ib_async.contract = contract_mod
 sys.modules.setdefault("ib_async", ib_async)
@@ -83,4 +85,3 @@ def test_rounds_and_drops_orders_below_min() -> None:
     assert trades == []
     assert gross == 400.0  # exposure unchanged
     assert lev == 0.4
-


### PR DESCRIPTION
## Summary
- silence mypy attribute warnings in sizing tests by annotating dummy `ib_async` modules

## Testing
- `pre-commit run --files tests/unit/test_sizing.py`
- `pytest -q tests/unit/test_sizing.py`


------
https://chatgpt.com/codex/tasks/task_e_68b78ee1cc0c8320b9295c54d432cc3f