### PR TITLE
Show trade quantities in preview

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -11,9 +11,10 @@ from rich.console import Console
 from rich.table import Table
 
 from .drift import Drift
+from .sizing import SizedTrade
 
 
-def render(plan: list[Drift]) -> str:
+def render(plan: list[Drift], trades: list[SizedTrade] | None = None) -> str:
     """Return a formatted table for the given drift plan.
 
     Parameters
@@ -33,15 +34,20 @@ def render(plan: list[Drift]) -> str:
     table.add_column("Current %", justify="right")
     table.add_column("Drift %", justify="right")
     table.add_column("Drift $", justify="right")
+    table.add_column("Qty", justify="right")
     table.add_column("Action")
 
+    qty_lookup = {t.symbol: t.quantity for t in (trades or [])}
+
     for d in plan:
+        qty = qty_lookup.get(d.symbol, 0.0)
         table.add_row(
             d.symbol,
             f"{d.target_wt_pct:.2f}",
             f"{d.current_wt_pct:.2f}",
             f"{d.drift_pct:.2f}",
             f"{d.drift_usd:.2f}",
+            f"{qty:.2f}",
             d.action,
         )
 

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -11,6 +11,7 @@ from rich import print
 from src.broker.ibkr_client import IBKRClient, IBKRError
 from src.core.drift import compute_drift, prioritize_by_drift
 from src.core.preview import render as render_preview
+from src.core.sizing import size_orders
 from src.io.config_loader import ConfigError, load_config
 from src.io.portfolio_csv import PortfolioCSVError, load_portfolios
 
@@ -51,7 +52,8 @@ async def _run(args: argparse.Namespace) -> None:
 
     drifts = compute_drift(current, targets, prices, net_liq, cfg)
     prioritized = prioritize_by_drift(drifts, cfg)
-    table = render_preview(prioritized)
+    trades, *_ = size_orders(prioritized, prices, current["CASH"], cfg)
+    table = render_preview(prioritized, trades)
     print(table)
     if args.dry_run:
         print("[green]Dry run complete (no orders submitted).[/green]")

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -6,10 +6,22 @@ from types import SimpleNamespace
 
 from src.core.drift import Drift, prioritize_by_drift
 from src.core.preview import render
+from src.core.sizing import size_orders
 
 
-def _cfg(min_usd: int) -> SimpleNamespace:
-    return SimpleNamespace(rebalance=SimpleNamespace(min_order_usd=min_usd))
+def _cfg(
+    min_usd: int,
+    allow_fractional: bool = True,
+    cash_buffer_pct: float = 0.0,
+    max_leverage: float = 1.0,
+) -> SimpleNamespace:
+    reb = SimpleNamespace(
+        min_order_usd=min_usd,
+        allow_fractional=allow_fractional,
+        cash_buffer_pct=cash_buffer_pct,
+        max_leverage=max_leverage,
+    )
+    return SimpleNamespace(rebalance=reb)
 
 
 def test_render_sorted_and_filtered() -> None:
@@ -25,3 +37,16 @@ def test_render_sorted_and_filtered() -> None:
 
     assert "BBB" not in table
     assert table.index("CCC") < table.index("AAA")
+
+
+def test_render_shows_quantities() -> None:
+    drifts = [Drift("AAA", 0.0, 0.0, 0.0, -100.0, "BUY")]
+    prices = {"AAA": 25.0}
+    cfg = _cfg(1)
+
+    prioritized = prioritize_by_drift(drifts, cfg)
+    trades, *_ = size_orders(prioritized, prices, cash=100.0, cfg=cfg)
+    table = render(prioritized, trades)
+
+    assert "Qty" in table
+    assert "4.00" in table


### PR DESCRIPTION
## Summary
- size orders after drift prioritization and render share quantities in preview table
- extend preview renderer to accept sized trades and show Qty column
- add unit test verifying preview includes computed quantities

## Testing
- `pre-commit run --files src/core/preview.py src/rebalance.py tests/unit/test_preview.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78fd4e7188320b55c238c40a7eb28