### PR TITLE
Use market prices for all symbols in rebalance

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -36,12 +36,14 @@ async def _run(args: argparse.Namespace) -> None:
 
         current = {p["symbol"]: float(p["position"]) for p in snapshot["positions"]}
         current["CASH"] = float(snapshot["cash"])
-        prices = {p["symbol"]: float(p["avg_cost"]) for p in snapshot["positions"]}
 
         symbols = set(current) | set(portfolios)
         symbols.discard("CASH")
-        missing = symbols - set(prices)
-        for symbol in missing:
+        prices: dict[str, float] = {}
+
+        # Use market prices for all symbols, including those already held, to
+        # ensure consistent valuation across the portfolio.
+        for symbol in symbols:
             try:
                 prices[symbol] = await get_price(
                     client._ib,

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -67,18 +67,18 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch) -> dict:
     return captured
 
 
-def test_run_fetches_missing_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_fetches_prices_for_all_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _setup_common(monkeypatch)
 
     async def fake_get_price(ib, symbol, *, price_source, fallback_to_snapshot):
-        return 20.0
+        return {"AAA": 15.0, "BBB": 20.0}[symbol]
 
     monkeypatch.setattr(rebalance, "get_price", fake_get_price)
 
     args = argparse.Namespace(config="cfg", csv="csv", dry_run=True, confirm=False)
     asyncio.run(rebalance._run(args))
 
-    assert captured["BBB"] == 20.0
+    assert captured == {"AAA": 15.0, "BBB": 20.0}
 
 
 def test_run_aborts_when_price_unavailable(
@@ -97,4 +97,4 @@ def test_run_aborts_when_price_unavailable(
 
     out, _ = capsys.readouterr()
     assert "bad price" in out
-    assert "BBB" not in captured
+    assert captured == {}


### PR DESCRIPTION
## Summary
- Replace reliance on snapshot average costs with live market pricing via `core.pricing.get_price`
- Update rebalance pricing tests to expect market lookups for both held and new symbols

## Testing
- `pre-commit run --files src/rebalance.py tests/unit/test_rebalance_pricing.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7926a44408320b3d7f13486d3195b