### PR TITLE
Qualify IB contracts before pricing

### DIFF
--- a/src/core/sizing.py
+++ b/src/core/sizing.py
@@ -88,9 +88,7 @@ def size_orders(
         exposure and leverage after applying the trades.
     """
 
-    min_order_usd, allow_fractional, cash_buffer_pct, max_leverage = _extract_cfg(
-        cfg
-    )
+    min_order_usd, allow_fractional, cash_buffer_pct, max_leverage = _extract_cfg(cfg)
 
     net_liq = _infer_net_liq(drifts, cash)
 
@@ -170,4 +168,3 @@ def size_orders(
 
 
 __all__ = ["SizedTrade", "size_orders"]
-

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -18,12 +18,20 @@ def test_get_price_live(monkeypatch: pytest.MonkeyPatch) -> None:
     """Live price is returned when available and snapshot is disabled."""
 
     ib = SimpleNamespace()
-    calls = []
+    qualify_calls: list = []
+    req_calls: list = []
+
+    qualified_contract = SimpleNamespace()
+
+    async def fake_qualify(contract):
+        qualify_calls.append(contract)
+        return [qualified_contract]
 
     async def fake_req(contract, *, snapshot: bool = False):
-        calls.append(snapshot)
+        req_calls.append((contract, snapshot))
         return [Ticker(last=100.0)]
 
+    monkeypatch.setattr(ib, "qualifyContractsAsync", fake_qualify, raising=False)
     monkeypatch.setattr(ib, "reqTickersAsync", fake_req, raising=False)
 
     price = asyncio.run(
@@ -31,21 +39,33 @@ def test_get_price_live(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert price == 100.0
-    assert calls == [False]
+    assert len(qualify_calls) == 1
+    assert req_calls == [(qualified_contract, False)]
+    assert getattr(qualify_calls[0], "symbol") == "AAPL"
+    assert getattr(qualify_calls[0], "exchange") == "SMART"
+    assert getattr(qualify_calls[0], "currency") == "USD"
 
 
 def test_get_price_falls_back_to_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
     """Snapshot price is used when live price is missing and fallback enabled."""
 
     ib = SimpleNamespace()
-    calls = []
+    qualify_calls: list = []
+    req_calls: list = []
+
+    qualified_contract = SimpleNamespace()
+
+    async def fake_qualify(contract):
+        qualify_calls.append(contract)
+        return [qualified_contract]
 
     async def fake_req(contract, *, snapshot: bool = False):
-        calls.append(snapshot)
+        req_calls.append((contract, snapshot))
         if snapshot:
             return [Ticker(last=50.0)]
         return [Ticker(last=None)]
 
+    monkeypatch.setattr(ib, "qualifyContractsAsync", fake_qualify, raising=False)
     monkeypatch.setattr(ib, "reqTickersAsync", fake_req, raising=False)
 
     price = asyncio.run(
@@ -53,19 +73,34 @@ def test_get_price_falls_back_to_snapshot(monkeypatch: pytest.MonkeyPatch) -> No
     )
 
     assert price == 50.0
-    assert calls == [False, True]
+    assert len(qualify_calls) == 1
+    assert req_calls == [
+        (qualified_contract, False),
+        (qualified_contract, True),
+    ]
+    assert getattr(qualify_calls[0], "symbol") == "AAPL"
+    assert getattr(qualify_calls[0], "exchange") == "SMART"
+    assert getattr(qualify_calls[0], "currency") == "USD"
 
 
 def test_get_price_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     """PricingError is raised when both live and snapshot prices are missing."""
 
     ib = SimpleNamespace()
-    calls = []
+    qualify_calls: list = []
+    req_calls: list = []
+
+    qualified_contract = SimpleNamespace()
+
+    async def fake_qualify(contract):
+        qualify_calls.append(contract)
+        return [qualified_contract]
 
     async def fake_req(contract, *, snapshot: bool = False):
-        calls.append(snapshot)
+        req_calls.append((contract, snapshot))
         return [Ticker(last=None)]
 
+    monkeypatch.setattr(ib, "qualifyContractsAsync", fake_qualify, raising=False)
     monkeypatch.setattr(ib, "reqTickersAsync", fake_req, raising=False)
 
     with pytest.raises(PricingError):
@@ -73,4 +108,40 @@ def test_get_price_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> N
             get_price(ib, "AAPL", price_source="last", fallback_to_snapshot=True)
         )
 
-    assert calls == [False, True]
+    assert len(qualify_calls) == 1
+    assert req_calls == [
+        (qualified_contract, False),
+        (qualified_contract, True),
+    ]
+    assert getattr(qualify_calls[0], "symbol") == "AAPL"
+    assert getattr(qualify_calls[0], "exchange") == "SMART"
+    assert getattr(qualify_calls[0], "currency") == "USD"
+
+
+def test_get_price_raises_when_contract_not_qualified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PricingError is raised if contract qualification returns nothing."""
+
+    ib = SimpleNamespace()
+    qualify_calls: list = []
+    req_calls: list = []
+
+    async def fake_qualify(contract):
+        qualify_calls.append(contract)
+        return []
+
+    async def fake_req(contract, *, snapshot: bool = False):
+        req_calls.append((contract, snapshot))
+        return [Ticker(last=100.0)]
+
+    monkeypatch.setattr(ib, "qualifyContractsAsync", fake_qualify, raising=False)
+    monkeypatch.setattr(ib, "reqTickersAsync", fake_req, raising=False)
+
+    with pytest.raises(PricingError):
+        asyncio.run(
+            get_price(ib, "AAPL", price_source="last", fallback_to_snapshot=True)
+        )
+
+    assert len(qualify_calls) == 1
+    assert req_calls == []


### PR DESCRIPTION
## Summary
- qualify Stock contracts before requesting market data and raise `PricingError` when qualification fails
- request tickers with the qualified contract for both live and snapshot modes
- stub `qualifyContractsAsync` in pricing tests and add coverage for qualification failures

## Testing
- `pytest tests/unit/test_pricing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7944b55588320a612e86cc52d4845