### PR TITLE
Switch percent config to fractions and add validation

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -27,14 +27,14 @@ per_holding_band_bps = 50
 portfolio_total_band_bps = 100
 ; Ignore trades below this USD amount
 min_order_usd = 50
-; Reserve this % of NetLiq as cash (1 = 1%)
-cash_buffer_pct = 1
+; Reserve this fraction of NetLiq as cash (0.01 = 1%)
+cash_buffer_pct = 0.01
 ; true allows fractional shares
 allow_fractional = false
 ; Max gross exposure multiple (e.g., 1.5 = 150%)
 max_leverage = 1.50
-; Placeholder maintenance margin buffer (not enforced)
-maintenance_buffer_pct = 10
+; Placeholder maintenance margin buffer (not enforced, 0.10 = 10%)
+maintenance_buffer_pct = 0.10
 ; true trades only during regular trading hours
 prefer_rth = true
 

--- a/dev-plan/srs.md
+++ b/dev-plan/srs.md
@@ -74,10 +74,10 @@ trigger_mode = per_holding        ; per_holding | total_drift
 per_holding_band_bps = 50         ; trade if |drift| > 0.50%
 portfolio_total_band_bps = 100    ; used when trigger_mode=total_drift
 min_order_usd = 500               ; ignore smaller trades
-cash_buffer_pct = 1               ; reserve 1% of NetLiq as cash (1 = 1%)
+cash_buffer_pct = 0.01            ; reserve 1% of NetLiq as cash (0.01 = 1%)
 allow_fractional = false          ; set true only if account supports it
 max_leverage = 1.50               ; hard cap on gross (e.g., 150%)
-maintenance_buffer_pct = 10       ; not used (rely on max_leverage)
+maintenance_buffer_pct = 0.10     ; not used (rely on max_leverage)
 prefer_rth = true                 ; place orders only during RTH by default
 
 [pricing]

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -139,10 +139,10 @@ trigger_mode = per_holding
 per_holding_band_bps = 50
 portfolio_total_band_bps = 100
 min_order_usd = 500
-cash_buffer_pct = 1
+cash_buffer_pct = 0.01
 allow_fractional = false
 max_leverage = 1.50
-maintenance_buffer_pct = 10
+maintenance_buffer_pct = 0.10
 prefer_rth = true
 
 [pricing]

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -46,7 +46,7 @@ class Rebalance:
     cash_buffer_pct: float  # decimal fraction (e.g., 0.01 = 1%)
     allow_fractional: bool
     max_leverage: float
-    maintenance_buffer_pct: float
+    maintenance_buffer_pct: float  # decimal fraction (e.g., 0.10 = 10%)
     prefer_rth: bool
 
 
@@ -150,7 +150,7 @@ def load_config(path: Path) -> AppConfig:
         per_holding_band_bps = cp.getint("rebalance", "per_holding_band_bps")
         portfolio_total_band_bps = cp.getint("rebalance", "portfolio_total_band_bps")
         min_order_usd = cp.getint("rebalance", "min_order_usd")
-        cash_buffer_pct = cp.getfloat("rebalance", "cash_buffer_pct") / 100.0
+        cash_buffer_pct = cp.getfloat("rebalance", "cash_buffer_pct")
         allow_fractional = cp.getboolean("rebalance", "allow_fractional")
         max_leverage = cp.getfloat("rebalance", "max_leverage")
         maintenance_buffer_pct = cp.getfloat("rebalance", "maintenance_buffer_pct")
@@ -163,12 +163,16 @@ def load_config(path: Path) -> AppConfig:
         raise ConfigError("[rebalance] portfolio_total_band_bps must be >= 0")
     if min_order_usd <= 0:
         raise ConfigError("[rebalance] min_order_usd must be positive")
-    if cash_buffer_pct < 0:
-        raise ConfigError("[rebalance] cash_buffer_pct must be >= 0")
+    if not 0 <= cash_buffer_pct <= 1:
+        raise ConfigError(
+            "[rebalance] cash_buffer_pct must be between 0 and 1"
+        )
     if max_leverage <= 0:
         raise ConfigError("[rebalance] max_leverage must be positive")
-    if maintenance_buffer_pct < 0:
-        raise ConfigError("[rebalance] maintenance_buffer_pct must be >= 0")
+    if not 0 <= maintenance_buffer_pct <= 1:
+        raise ConfigError(
+            "[rebalance] maintenance_buffer_pct must be between 0 and 1"
+        )
     rebalance = Rebalance(
         trigger_mode=trigger_mode,
         per_holding_band_bps=per_holding_band_bps,

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -35,10 +35,10 @@ trigger_mode = per_holding
 per_holding_band_bps = 50
 portfolio_total_band_bps = 100
 min_order_usd = 500
-cash_buffer_pct = 1
+cash_buffer_pct = 0.01
 allow_fractional = false
 max_leverage = 1.50
-maintenance_buffer_pct = 10
+maintenance_buffer_pct = 0.10
 prefer_rth = true
 
 [pricing]
@@ -83,7 +83,7 @@ def test_load_valid_config(config_file: Path) -> None:
             cash_buffer_pct=0.01,
             allow_fractional=False,
             max_leverage=1.50,
-            maintenance_buffer_pct=10,
+            maintenance_buffer_pct=0.10,
             prefer_rth=True,
         ),
         pricing=Pricing(price_source="last", fallback_to_snapshot=True),
@@ -128,6 +128,26 @@ def test_non_numeric_port(tmp_path: Path) -> None:
 def test_negative_per_holding_band_bps(tmp_path: Path) -> None:
     content = VALID_CONFIG.replace(
         "per_holding_band_bps = 50", "per_holding_band_bps = -5"
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
+def test_cash_buffer_pct_out_of_range(tmp_path: Path) -> None:
+    content = VALID_CONFIG.replace(
+        "cash_buffer_pct = 0.01", "cash_buffer_pct = 1.5"
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
+def test_cash_buffer_pct_negative(tmp_path: Path) -> None:
+    content = VALID_CONFIG.replace(
+        "cash_buffer_pct = 0.01", "cash_buffer_pct = -0.2"
     )
     path = tmp_path / "settings.ini"
     path.write_text(content)


### PR DESCRIPTION
## Summary
- switch percent settings in config to fractional values (0.01 = 1%)
- validate cash and maintenance buffers are between 0 and 1
- add tests for invalid percentage values and update documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7994c0bbc832097e087f3ec85704d