### PR TITLE
feat: display price in preview table

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 from rich.console import Console
 from rich.table import Table
+from typing import Mapping
 
 from .drift import Drift
 from .sizing import SizedTrade
 
 
-def render(plan: list[Drift], trades: list[SizedTrade] | None = None) -> str:
+def render(
+    plan: list[Drift],
+    trades: list[SizedTrade] | None = None,
+    prices: Mapping[str, float] | None = None,
+) -> str:
     """Return a formatted table for the given drift plan.
 
     Parameters
@@ -34,19 +39,23 @@ def render(plan: list[Drift], trades: list[SizedTrade] | None = None) -> str:
     table.add_column("Current %", justify="right")
     table.add_column("Drift %", justify="right")
     table.add_column("Drift $", justify="right")
+    table.add_column("Price", justify="right")
     table.add_column("Qty", justify="right")
     table.add_column("Action")
 
     qty_lookup = {t.symbol: t.quantity for t in (trades or [])}
+    price_lookup = prices or {}
 
     for d in plan:
         qty = qty_lookup.get(d.symbol, 0.0)
+        price = price_lookup.get(d.symbol)
         table.add_row(
             d.symbol,
             f"{d.target_wt_pct:.2f}",
             f"{d.current_wt_pct:.2f}",
             f"{d.drift_pct:.2f}",
             f"{d.drift_usd:.2f}",
+            f"{price:.2f}" if price is not None else "-",
             f"{qty:.2f}",
             d.action,
         )
@@ -63,4 +72,4 @@ if __name__ == "__main__":  # pragma: no cover - convenience demo
         Drift("AAA", 50.0, 60.0, 10.0, 640.0, "SELL"),
         Drift("BBB", 50.0, 40.0, -10.0, -640.0, "BUY"),
     ]
-    print(render(sample_plan))
+    print(render(sample_plan, prices={"AAA": 100.0, "BBB": 90.0}))

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -72,7 +72,7 @@ async def _run(args: argparse.Namespace) -> None:
     drifts = compute_drift(current, targets, prices, net_liq, cfg)
     prioritized = prioritize_by_drift(drifts, cfg)
     trades, *_ = size_orders(prioritized, prices, current["CASH"], cfg)
-    table = render_preview(prioritized, trades)
+    table = render_preview(prioritized, trades, prices)
     print(table)
     if args.dry_run:
         print("[green]Dry run complete (no orders submitted).[/green]")

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -30,11 +30,13 @@ def test_render_sorted_and_filtered() -> None:
         Drift("BBB", 0.0, 0.0, 0.0, 80.0, "SELL"),
         Drift("CCC", 0.0, 0.0, 0.0, 200.0, "SELL"),
     ]
+    prices = {"AAA": 1.0, "BBB": 2.0, "CCC": 3.0}
     cfg = _cfg(100)
 
     prioritized = prioritize_by_drift(drifts, cfg)
-    table = render(prioritized)
+    table = render(prioritized, prices=prices)
 
+    assert "Price" in table
     assert "BBB" not in table
     assert table.index("CCC") < table.index("AAA")
 
@@ -46,7 +48,8 @@ def test_render_shows_quantities() -> None:
 
     prioritized = prioritize_by_drift(drifts, cfg)
     trades, *_ = size_orders(prioritized, prices, cash=100.0, cfg=cfg)
-    table = render(prioritized, trades)
+    table = render(prioritized, trades, prices)
 
+    assert "Price" in table
     assert "Qty" in table
     assert "4.00" in table

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -61,7 +61,7 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch) -> dict:
         rebalance, "size_orders", lambda prioritized, prices, cash, cfg: ([], [], [])
     )
     monkeypatch.setattr(
-        rebalance, "render_preview", lambda prioritized, trades: "TABLE"
+        rebalance, "render_preview", lambda prioritized, trades, prices: "TABLE"
     )
 
     return captured


### PR DESCRIPTION
## Summary
- extend preview renderer to include Price column and accept price data
- pass price mapping from rebalance CLI
- update unit tests for price-aware rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a27b90488320ba9188c889152f11