### PR TITLE
style: reorder imports in preview

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -7,9 +7,10 @@ side effects beyond returning the rendered string.
 
 from __future__ import annotations
 
+from typing import Mapping
+
 from rich.console import Console
 from rich.table import Table
-from typing import Mapping
 
 from .drift import Drift
 from .sizing import SizedTrade


### PR DESCRIPTION
## Summary
- reorder imports in preview module to place typing before third-party imports

## Testing
- `isort --check-only src/core/preview.py -v`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5db39988320a109c6a9ee5dce6e