### PR TITLE
Integrate order sizing preview and confirmation logic

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -19,6 +19,8 @@ def render(
     trades: list[SizedTrade] | None = None,
     pre_gross_exposure: float = 0.0,
     pre_leverage: float = 0.0,
+    post_gross_exposure: float = 0.0,
+    post_leverage: float = 0.0,
 ) -> str:
     """Return a formatted table for the given drift plan.
 
@@ -33,6 +35,10 @@ def render(
         Portfolio gross exposure before applying the trades.
     pre_leverage:
         Portfolio leverage before applying the trades.
+    post_gross_exposure:
+        Projected portfolio gross exposure after applying the trades.
+    post_leverage:
+        Projected portfolio leverage after applying the trades.
 
     Returns
     -------
@@ -75,10 +81,6 @@ def render(
     gross_buy = sum(t.notional for t in (trades or []) if t.action == "BUY")
     gross_sell = sum(t.notional for t in (trades or []) if t.action == "SELL")
 
-    post_gross_exposure = pre_gross_exposure + gross_buy - gross_sell
-    net_liq = pre_gross_exposure / pre_leverage if pre_leverage else 0.0
-    post_leverage = post_gross_exposure / net_liq if net_liq else 0.0
-
     summary = Table(title="Batch Summary", show_header=False)
     summary.add_column("Metric")
     summary.add_column("Value", justify="right")
@@ -103,4 +105,8 @@ if __name__ == "__main__":  # pragma: no cover - convenience demo
         SizedTrade("AAA", "SELL", 6.4, 640.0),
         SizedTrade("BBB", "BUY", 7.111111, 640.0),
     ]
-    print(render(sample_plan, sample_trades, 1000.0, 1.0))
+    pre_exp = 1000.0
+    pre_lev = 1.0
+    post_exp = pre_exp - 640.0 + 640.0  # no change in this demo
+    post_lev = post_exp / (pre_exp / pre_lev)
+    print(render(sample_plan, sample_trades, pre_exp, pre_lev, post_exp, post_lev))

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -33,7 +33,7 @@ def test_render_sorted_and_filtered() -> None:
     cfg = _cfg(100)
 
     prioritized = prioritize_by_drift(drifts, cfg)
-    table = render(prioritized, [], 0.0, 0.0)
+    table = render(prioritized, [], 0.0, 0.0, 0.0, 0.0)
 
     assert "Drift %" in table
     assert "BBB" not in table
@@ -46,8 +46,8 @@ def test_render_shows_quantities_and_notional() -> None:
     cfg = _cfg(1)
 
     prioritized = prioritize_by_drift(drifts, cfg)
-    trades, *_ = size_orders(prioritized, prices, cash=100.0, cfg=cfg)
-    table = render(prioritized, trades, 100.0, 1.0)
+    trades, post_exp, post_lev = size_orders(prioritized, prices, cash=100.0, cfg=cfg)
+    table = render(prioritized, trades, 100.0, 1.0, post_exp, post_lev)
 
     assert "Qty" in table
     assert "Notional" in table
@@ -65,7 +65,20 @@ def test_render_batch_summary() -> None:
         SizedTrade("BBB", "SELL", 10.0, 50.0),
     ]
 
-    table = render(drifts, trades, pre_gross_exposure=500.0, pre_leverage=1.0)
+    pre_exp = 500.0
+    pre_lev = 1.0
+    gross_buy = 100.0
+    gross_sell = 50.0
+    post_exp = pre_exp + gross_buy - gross_sell
+    post_lev = post_exp / (pre_exp / pre_lev)
+    table = render(
+        drifts,
+        trades,
+        pre_gross_exposure=pre_exp,
+        pre_leverage=pre_lev,
+        post_gross_exposure=post_exp,
+        post_leverage=post_lev,
+    )
 
     header = table.splitlines()[1]
     assert (


### PR DESCRIPTION
## Summary
- feed sizing results into preview with pre/post exposure and leverage metrics
- gate submissions with dry-run, confirmation, and read-only flags
- document new CLI flags and update preview test expectations

## Testing
- `pre-commit run --all-files`
- `PYTHONPATH=. pytest -q tests/unit/test_preview.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7a9a84120832096db4c1885ddee62