### PR TITLE
Document preview batch summary and read-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,24 @@ Generate a table of drift metrics:
 python -m src.core.preview
 ```
 
+The main rebalancer prints a batch summary preview before submitting trades.
+
 ### Dry run
 Launch IB Gateway or Trader Workstation, then run:
 
 ```bash
 python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
 ```
+Displays the batch summary and exits without placing orders.
 
 ### Confirmed execution
 ```bash
 python src/rebalance.py --confirm --config config/settings.ini --csv data/portfolios.csv
 ```
+Shows the same preview and waits for `y` before trading.
+
+### Read-only guard
+```bash
+python src/rebalance.py --read-only --config config/settings.ini --csv data/portfolios.csv
+```
+Forces preview-only mode even if `--confirm` is used.

--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -90,12 +90,12 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 - [X] Unit tests enforce `min_order_usd` after rounding
 
 ### Phase C4 — Preview & CLI Confirmation
-- [ ] `src/core/preview.py` implemented
-- [ ] `src/rebalance.py` orchestrates end-to-end
-- [ ] CLI flags: `--dry-run`, `--confirm`, `--read-only`, `--config`, `--csv`
-- [ ] Trade plan shows drift % and $; batch summary visible
-- [ ] Y/N prompt blocks execution unless confirmed
-- [ ] End-to-end dry-run tested with fixtures
+- [x] `src/core/preview.py` implemented with batch summary preview
+- [x] `src/rebalance.py` orchestrates end-to-end
+- [x] CLI flags: `--dry-run`, `--confirm`, `--read-only`, `--config`, `--csv`
+- [x] Trade plan shows drift % and $; batch summary visible before prompt
+- [x] Y/N prompt blocks execution unless confirmed
+- [x] End-to-end dry-run tested with fixtures
 
 ---
 

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -185,17 +185,18 @@ _Status: Implemented in [`src/core/pricing.py`](../src/core/pricing.py)._
 ---
 
 #### Phase C4: Preview & CLI confirmation
+_Status: Completed with batch-summary preview._
 **Deliverables**
-- `src/core/preview.py` renders a tabular **trade plan** (drift in % and $), batch summary (gross buy/sell, pre/post gross exposure & leverage)
+- `src/core/preview.py` renders a tabular **trade plan** (drift in % and $) and batch summary (gross buy/sell, pre/post gross exposure & leverage) before confirmation
 - `rebalance.py` orchestrates: load → snapshot → targets → drift → sizing → preview → **CLI Y/N**
-- `--dry-run` flag (no trading), `--read-only` guard
+- CLI flags: `--dry-run` (preview only), `--confirm` (execute after prompt), `--read-only` guard
 
 **Tests**
-- [ ] End-to-end dry-run on sample data  
-- [ ] Output formatting stable for CSV reporter
+- [x] End-to-end dry-run on sample data
+- [x] Output formatting stable for CSV reporter
 
 **Acceptance**
-- Preview shows correct math; prompt works as specified
+- Batch summary preview shows correct math; prompt works as specified
 
 ---
 

--- a/dev-plan/srs.md
+++ b/dev-plan/srs.md
@@ -119,8 +119,8 @@ log_level = INFO
    - `allow_fractional` (generally false) → round to whole shares.  
    - **Leverage guard**: size partially so post-trade **gross exposure / NetLiq ≤ max_leverage**. If cannot meet, reduce orders proportionally by drift priority list.
 9. **Preview** (no orders yet):
-   - Produce a **trade plan** table with **% drift and $ drift**, target weights, estimated $ values, estimated post-trade weights.  
-   - Show **batch summary** (gross to buy/sell, est. exposure, leverage).  
+   - Produce a **trade plan** table with **% drift and $ drift**, target weights, estimated $ values, estimated post-trade weights.
+   - Show a **batch summary** (gross to buy/sell, est. exposure, leverage) before prompting.
    - Prompt **Y/N** at CLI.
 10. **Execute** (on `Y`):
     - Submit **batch market orders** with preferred **algo** (adaptive or midprice) when supported by IBKR; otherwise **fallback to plain market**.
@@ -130,9 +130,11 @@ log_level = INFO
 12. **Exit**.
 
 ### 4.2 Command-line UX
-- `python rebalance.py --confirm` → runs full flow with preview and Y/N prompt.  
-- `python rebalance.py --dry-run` → runs through preview only; **no orders** possible (overrides `--confirm`).  
-- `python rebalance.py --read-only` → enforce no trading even after Y (useful while testing).
+All runs display the batch-summary preview before asking for confirmation.
+
+- `python rebalance.py --confirm` → preview then optional order submission after Y/N prompt.
+- `python rebalance.py --dry-run` → preview only; **no orders** possible (overrides `--confirm`).
+- `python rebalance.py --read-only` → safety flag; shows preview but never trades even after Y.
 
 **Confirmation prompt example:**
 ```
@@ -260,7 +262,7 @@ Proceed? [y/N]:
 5. **Prioritization & leverage**
    - Greedy by |drift| when cash constrained; scaling to satisfy `max_leverage`.
 6. **Preview**
-   - Shows % and $ drift; batch summary; Y/N prompt; `--dry-run` prints only.
+   - Shows % and $ drift; batch summary; Y/N prompt; `--dry-run` and `--read-only` print only.
 7. **Execution**
    - Algo market OK; fallback to plain market when algo unavailable.
 8. **Reporting**

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -346,10 +346,11 @@ def load_config(path: str):
 ---
 
 ### C4. Preview & CLI confirmation
+_Status: Completed — preview shows batch summary before prompting._
 
-**Implement** `src/core/preview.py` and wire `src/rebalance.py`
-- Render a tabular plan with drift **% and $** per symbol; batch summary: gross buy/sell, pre/post exposure & leverage.  
-- CLI flags: `--dry-run`, `--confirm`, `--config`, `--csv`, `--read-only`.
+`src/core/preview.py` is wired into `src/rebalance.py`.
+- Renders a tabular plan with drift **% and $** per symbol and a batch summary (gross buy/sell, pre/post exposure & leverage) before the prompt.
+- CLI flags: `--dry-run` (preview only), `--confirm` (execute after `y`), `--read-only` guard. `--config` and `--csv` select inputs.
 
 **Preview example (console)**
 ```


### PR DESCRIPTION
## Summary
- Expand README usage with dry-run, confirm, and read-only examples and mention batch-summary preview
- Mark Phase C4 complete across dev-plan docs and describe preview behaviour
- Clarify SRS command-line UX with batch-summary preview and flags

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b7ac88babc8320a1a29a3b850e9aab