### PR TITLE
Fix preview renderer header missing when not terminal

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -75,7 +75,14 @@ def render(
 
     from io import StringIO
 
-    console = Console(file=StringIO(), record=True)
+    # Rich will downgrade its output when the destination isn't a real
+    # terminal (``isatty`` returns ``False``).  In the unit tests we render the
+    # table to an in-memory ``StringIO`` which Rich interprets as a plain file
+    # and therefore falls back to an ASCII only box drawing style and, more
+    # problematically, drops the header text.  Force terminal mode so that the
+    # exported table is stable and always uses the Unicode box characters the
+    # tests expect.
+    console = Console(file=StringIO(), record=True, force_terminal=True)
     console.print(table)
 
     gross_buy = sum(t.notional for t in (trades or []) if t.action == "BUY")


### PR DESCRIPTION
## Summary
- Force rich `Console` to treat StringIO output as a terminal so table headers render with Unicode box characters
- Add explanation comment for why `force_terminal` is needed

## Testing
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b7b049282483208f992e2f58a2a449