### PR TITLE
docs: expand reporting checklist

### DIFF
--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -112,8 +112,13 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 ### Phase D2 — Reporting & Logging
 - [ ] `src/io/reporting.py` implemented
 - [ ] Timestamped CSV written to `reports/`
-- [ ] CSV includes all SRS columns: `timestamp_run`, `account_id`, `symbol`, `is_cash`, `target_wt_pct`, `current_wt_pct`, `drift_pct`, `drift_usd`, `action`, `qty_shares`, `est_price`, `order_type`, `algo`, `est_value_usd`, `pre_gross_exposure`, `post_gross_exposure`, `pre_leverage`, `post_leverage`, `status`, `error`, `notes`
+- [ ] Pre-trade report generated
+- [ ] Post-trade report generated
+- [ ] Pre-trade CSV matches schema: `timestamp_run`, `account_id`, `symbol`, `is_cash`, `target_wt_pct`, `current_wt_pct`, `drift_pct`, `drift_usd`, `action`, `qty_shares`, `est_price`, `order_type`, `algo`, `est_value_usd`, `pre_gross_exposure`, `post_gross_exposure`, `pre_leverage`, `post_leverage`
+- [ ] Post-trade CSV matches schema: `timestamp_run`, `account_id`, `symbol`, `is_cash`, `target_wt_pct`, `current_wt_pct`, `drift_pct`, `drift_usd`, `action`, `qty_shares`, `est_price`, `order_type`, `algo`, `est_value_usd`, `pre_gross_exposure`, `post_gross_exposure`, `pre_leverage`, `post_leverage`, `status`, `error`, `notes`
 - [ ] Logs include INFO/ERROR messages for validation and order states
+- [ ] Logs note pre-trade report generation
+- [ ] Logs note post-trade report generation
 - [ ] Logs capture connection events, pacing/backoff messages, and a final summary
 - [ ] Unit tests check CSV schema and content
 


### PR DESCRIPTION
## Summary
- clarify Phase D2 reporting checklist with pre- and post-trade items
- separate CSV schema verification for pre- and post-trade reports
- ensure logs record both report-generation steps

## Testing
- `pre-commit run --files dev-plan/checklist.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b0aa28a88320ba75f78b7af2bb9b