### PR TITLE
Ensure Rich preview uses heavy box characters on Windows

### DIFF
--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -96,12 +96,15 @@ def render(
     # in reduced widths or ASCII only tables when rendering to an in-memory
     # ``StringIO`` buffer during testing.  Explicitly widen the virtual
     # terminal to ensure that column headers are never truncated regardless of
-    # the executing environment.
+    # the executing environment.  ``legacy_windows`` is disabled so that Rich
+    # doesn't substitute heavy box drawing characters on Windows, keeping the
+    # header separators consistent across platforms.
     console = Console(
         file=StringIO(),
         record=True,
         force_terminal=True,
         width=120,
+        legacy_windows=False,
     )
     console.print(table)
 


### PR DESCRIPTION
## Summary
- prevent Rich from substituting box-drawing characters by disabling legacy Windows mode
- document reasoning for forcing heavy box separators

## Testing
- `pytest -q`
- `python - <<'PY'
from src.core.preview import render
from src.core.drift import Drift
from src.core.sizing import SizedTrade
plan=[Drift('AAA',0,0,0,0,'HOLD')]
print(render(plan, [],0,0,0,0).splitlines()[1])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b7b918b2f48320a31c901933028fe5