### PR TITLE
feat: implement IBKR batch execution

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -1,4 +1,98 @@
-# Placeholder execution module for market orders with optional algo
-def submit_batch(orders, prefer_algo=True):
-    # TODO: integrate ib_async
-    return [{"symbol": o.get("symbol"), "status": "Filled"} for o in orders]
+"""Order execution helpers for submitting trades via ib_async."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import time
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ib_async.contract import Stock
+from ib_async.order import MarketOrder, TagValue
+
+from src.core.sizing import SizedTrade as Trade
+from src.io.config_loader import AppConfig as Config
+
+from .ibkr_client import IBKRClient, IBKRError
+
+
+async def submit_batch(
+    client: IBKRClient, trades: list[Trade], cfg: Config
+) -> list[dict[str, Any]]:
+    """Submit a batch of market orders and wait for completion.
+
+    Parameters
+    ----------
+    client:
+        Connected :class:`IBKRClient` instance.
+    trades:
+        Sized trades to execute.
+    cfg:
+        Application configuration providing execution and rebalance settings.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Structured execution results for each trade.
+    """
+
+    ib = client._ib
+
+    if cfg.rebalance.prefer_rth:
+        try:
+            server_now = await ib.reqCurrentTimeAsync()
+        except Exception as exc:  # pragma: no cover - network errors
+            raise IBKRError("Failed to query current time") from exc
+        if server_now.tzinfo is None:
+            server_now = server_now.replace(tzinfo=ZoneInfo("UTC"))
+        ny_time = server_now.astimezone(ZoneInfo("America/New_York")).time()
+        if not (time(9, 30) <= ny_time <= time(16, 0)):
+            raise IBKRError(
+                "Current time outside 09:30-16:00 America/New_York; "
+                "set rebalance.prefer_rth=False to override"
+            )
+
+    async def _wait(trade: Any) -> str:
+        terminal = {"Filled", "Cancelled", "ApiCancelled", "Rejected", "Inactive"}
+        while True:
+            status = getattr(trade.orderStatus, "status", "")
+            if status in terminal:
+                return status
+            await trade.updateEvent.wait()
+            trade.updateEvent.clear()
+
+    async def _submit_one(st: Trade) -> dict[str, Any]:
+        contract = Stock(st.symbol, "SMART", "USD")
+        order = MarketOrder(st.action, st.quantity)
+        algo_used = False
+        algo_pref = cfg.execution.algo_preference.lower()
+        if algo_pref in {"adaptive", "midprice"}:
+            algo_used = True
+            if algo_pref == "adaptive":
+                order.algoStrategy = "Adaptive"
+                order.algoParams = [TagValue("adaptivePriority", "Normal")]
+            elif algo_pref == "midprice":
+                order.algoStrategy = "ArrivalPx"
+                order.algoParams = [TagValue("strategyType", "Midpoint")]
+        ib_trade = await ib.placeOrderAsync(contract, order)
+        status = await _wait(ib_trade)
+        if (
+            algo_used
+            and status in {"Rejected", "Cancelled", "ApiCancelled", "Inactive"}
+            and cfg.execution.fallback_plain_market
+        ):
+            plain = MarketOrder(st.action, st.quantity)
+            ib_trade = await ib.placeOrderAsync(contract, plain)
+            status = await _wait(ib_trade)
+        return {
+            "symbol": st.symbol,
+            "order_id": getattr(ib_trade.order, "orderId", None),
+            "status": status,
+            "filled": getattr(ib_trade.orderStatus, "filled", 0.0),
+            "avg_fill_price": getattr(ib_trade.orderStatus, "avgFillPrice", 0.0),
+        }
+
+    return list(await asyncio.gather(*[_submit_one(t) for t in trades]))
+
+
+__all__ = ["submit_batch"]


### PR DESCRIPTION
## Summary
- add async submit_batch for market orders with adaptive/midprice algo support and fallback
- enforce RTH check via server time before submitting batch
- track order IDs and await terminal order states

## Testing
- `pre-commit run --files src/broker/execution.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7ba25dd6083209bf5ea1cfe739a0b