### PR TITLE
Remove trade list in rebalance submit and use sized trades directly

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -114,15 +114,10 @@ async def _run(args: argparse.Namespace) -> None:
             print("[yellow]Aborted by user.[/yellow]")
             return
 
-    trade_list = [
-        {"symbol": t.symbol, "action": t.action, "quantity": t.quantity}
-        for t in trades
-    ]
-
     print("[blue]Submitting batch market orders[/blue]")
     await client.connect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
     try:
-        results = await submit_batch(client, trade_list, cfg)
+        results = await submit_batch(client, trades, cfg)
     finally:
         await client.disconnect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
 

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -68,7 +68,7 @@ def test_run_submits_orders_and_prints_summary(monkeypatch, capsys):
     args = argparse.Namespace(config="cfg", csv="csv", dry_run=False, yes=True, read_only=False)
     asyncio.run(rebalance._run(args))
 
-    assert recorded["trades"] == [{"symbol": "AAA", "action": "BUY", "quantity": 5.0}]
+    assert recorded["trades"] == [SizedTrade("AAA", "BUY", 5.0, 50.0)]
     out, _ = capsys.readouterr()
     assert "AAA" in out and "Filled" in out
 


### PR DESCRIPTION
## Summary
- Call `submit_batch` with `SizedTrade` objects instead of building a dict list
- Update unit test to expect `SizedTrade` list when tracking submitted trades

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c118cb508320a3b7c91913b4cdc2