### PR TITLE
docs: record execution module behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,24 @@ Skips the confirmation prompt and submits orders immediately.
 python src/rebalance.py --read-only --config config/settings.ini --csv data/portfolios.csv
 ```
 Forces preview-only mode even if `--yes` is used.
+
+### Order execution module
+`src/broker/execution.py` submits the confirmed trades and supports IBKR's
+Adaptive or Midprice algos via `execution.algo_preference`. If the selected
+algo is rejected and `fallback_plain_market` is true, it retries with a plain
+market order. When `rebalance.prefer_rth` is enabled, the module queries the
+IBKR server clock and only proceeds between 09:30 and 16:00
+America/New_York.
+
+### Execution integration test
+Verify end-to-end submission against a paper account:
+
+```powershell
+$env:IBKR_HOST="127.0.0.1"
+$env:IBKR_PORT="4002"
+$env:IBKR_CLIENT_ID="7"
+pytest -q tests/integration/test_execution_paper.py
+```
+
+The test skips if the connection variables are missing or, with
+`rebalance.prefer_rth=true`, when run outside regular trading hours.

--- a/dev-plan/checklist.md
+++ b/dev-plan/checklist.md
@@ -102,12 +102,14 @@ Use this as a **living PR checklist**. Each phase must meet its acceptance items
 ## Milestone D — Execution & Reporting
 
 ### Phase D1 — Order Submission
-- [ ] `src/broker/execution.py` implemented
-- [ ] Market orders with preferred algo; fallback plain market
-- [ ] Batch submission; track order IDs
-- [ ] Respect `prefer_rth` (block outside RTH)
-- [ ] Integration test with tiny paper trade
-- [ ] Unit tests for rejection/partial fill paths
+- [x] `src/broker/execution.py` implemented
+- [x] Market orders with preferred algo; fallback plain market
+- [x] Batch submission; track order IDs
+- [x] Respect `prefer_rth` (block outside RTH)
+- [x] Integration test with tiny paper trade
+- [x] Unit tests for rejection/partial fill paths
+
+_Follow-up:_ capture partial fill metrics and consider extended-hours support.
 
 ### Phase D2 — Reporting & Logging
 - [ ] `src/io/reporting.py` implemented

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -369,13 +369,15 @@ Proceed? [y/N]:
 
 ### D1. Order submission (market + algo; fallback plain market)
 
+*Runs after the user confirms the preview in Phase C4.*
+
 **Implement** `src/broker/execution.py`
-- Build **market orders**; set algo preference (`adaptive`/`midprice`) where supported; else **fallback to plain market**.  
-- Batch submit; track order IDs; poll until Filled/Rejected/Cancelled.  
-- Respect `prefer_rth` (initially block with message if outside RTH).
+- Build **market orders**; set algo preference (`adaptive`/`midprice`) where supported; else **fallback to plain market**.
+- Batch submit; track order IDs; poll until Filled/Rejected/Cancelled.
+- Query server clock and block outside 09:30–16:00 America/New_York when `prefer_rth` is true.
 
 **Tests**
-- Integration (paper): tiny trade on a liquid ETF (e.g., SPY/IAU).  
+- Integration (paper): run `pytest tests/integration/test_execution_paper.py` with `IBKR_HOST/PORT/CLIENT_ID` set.
 - Unit/mocked: rejection paths, partial fills.
 
 **Acceptance**


### PR DESCRIPTION
## Summary
- document execution module's algo fallback and RTH gate
- note order submission after preview in workflow and mark Phase D1 complete
- add instructions for execution integration test

## Testing
- `pre-commit run --files README.md dev-plan/checklist.md dev-plan/workflow.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7c0bc599083208c9dccdb1a5a161b