### PR TITLE
Cast IB client to Any for mypy attr-defined fix

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import time
-from typing import Any
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 from ib_async.contract import Stock
@@ -36,7 +36,7 @@ async def submit_batch(
         Structured execution results for each trade.
     """
 
-    ib = client._ib
+    ib = cast(Any, client._ib)
 
     if cfg.rebalance.prefer_rth:
         try:


### PR DESCRIPTION
## Summary
- fix mypy attr-defined errors in execution by casting client IB instance to `Any`

## Testing
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c4fc40708320b041e478b19b8f30