### PR TITLE
Fetch prices concurrently during rebalance

### DIFF
--- a/tests/integration/test_rebalance_dry_run.py
+++ b/tests/integration/test_rebalance_dry_run.py
@@ -40,10 +40,8 @@ class DummyIBKRClient:
         }
 
 
-async def fake_get_price(
-    ib, symbol, *, price_source, fallback_to_snapshot
-):  # noqa: ARG001
-    return 100.0
+async def fake_fetch_price(ib, symbol, cfg):  # noqa: ARG001
+    return symbol, 100.0
 
 
 async def fake_validate_symbols(symbols, host, port, client_id):  # noqa: ARG001, D401
@@ -52,7 +50,7 @@ async def fake_validate_symbols(symbols, host, port, client_id):  # noqa: ARG001
 
 def test_rebalance_dry_run(monkeypatch, capsys):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
-    monkeypatch.setattr(rebalance, "get_price", fake_get_price)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
 
     args = Namespace(

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -68,10 +68,10 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch) -> dict:
 def test_run_fetches_prices_for_all_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _setup_common(monkeypatch)
 
-    async def fake_get_price(ib, symbol, *, price_source, fallback_to_snapshot):
-        return {"AAA": 15.0, "BBB": 20.0}[symbol]
+    async def fake_fetch_price(ib, symbol, cfg):
+        return symbol, {"AAA": 15.0, "BBB": 20.0}[symbol]
 
-    monkeypatch.setattr(rebalance, "get_price", fake_get_price)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     args = argparse.Namespace(
         config="cfg", csv="csv", dry_run=True, yes=False, read_only=False
@@ -86,10 +86,10 @@ def test_run_aborts_when_price_unavailable(
 ) -> None:
     captured = _setup_common(monkeypatch)
 
-    async def fake_get_price(ib, symbol, *, price_source, fallback_to_snapshot):
+    async def fake_fetch_price(ib, symbol, cfg):
         raise PricingError("bad price")
 
-    monkeypatch.setattr(rebalance, "get_price", fake_get_price)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     args = argparse.Namespace(
         config="cfg", csv="csv", dry_run=True, yes=False, read_only=False

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -44,10 +44,10 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(rebalance, "IBKRClient", lambda: FakeClient())
 
-    async def fake_get_price(ib, symbol, *, price_source, fallback_to_snapshot):
-        return 10.0
+    async def fake_fetch_price(ib, symbol, cfg):
+        return symbol, 10.0
 
-    monkeypatch.setattr(rebalance, "get_price", fake_get_price)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     monkeypatch.setattr(rebalance, "compute_drift", lambda *a, **k: [])
     monkeypatch.setattr(rebalance, "prioritize_by_drift", lambda drifts, cfg: [])


### PR DESCRIPTION
## Summary
- fetch symbol prices concurrently with asyncio tasks
- add helper wrapper for get_price and error handling
- update tests for concurrent price lookup and order submission

## Testing
- `python -m pre_commit run --files src/rebalance.py tests/integration/test_rebalance_dry_run.py tests/integration/test_rebalance_confirmation.py tests/unit/test_rebalance_pricing.py tests/unit/test_rebalance_submit.py`
- `pytest tests/unit/test_rebalance_pricing.py tests/unit/test_rebalance_submit.py`
- `pytest -m "integration" tests/integration/test_rebalance_dry_run.py tests/integration/test_rebalance_confirmation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7c62ae7b08320b0fcc968934e17ee