### PR TITLE
Switch to statusEvent for trade completion checks

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -58,8 +58,8 @@ async def submit_batch(
             status = getattr(trade.orderStatus, "status", "")
             if status in terminal:
                 return status
-            await trade.updateEvent.wait()
-            trade.updateEvent.clear()
+            await trade.statusEvent.wait()
+            trade.statusEvent.clear()
 
     async def _submit_one(st: Trade) -> dict[str, Any]:
         contract = Stock(st.symbol, "SMART", "USD")

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -16,7 +16,7 @@ class DummyTrade:
             status=status, filled=filled, avgFillPrice=0.0
         )
         self.order = SimpleNamespace(orderId=1)
-        self.updateEvent = asyncio.Event()
+        self.statusEvent = asyncio.Event()
 
 
 class FakeClient:
@@ -75,11 +75,11 @@ def test_partial_fill_reports_final_quantity(monkeypatch):
             await asyncio.sleep(0)
             trade.orderStatus.status = "PartiallyFilled"
             trade.orderStatus.filled = 5.0
-            trade.updateEvent.set()
+            trade.statusEvent.set()
             await asyncio.sleep(0)
             trade.orderStatus.status = "Filled"
             trade.orderStatus.filled = 10.0
-            trade.updateEvent.set()
+            trade.statusEvent.set()
 
         asyncio.create_task(updates())
         return trade


### PR DESCRIPTION
## Summary
- Wait on `statusEvent` in execution helper to detect order completion
- Adapt unit tests to use `statusEvent` for trade updates

## Testing
- `pre-commit run --files src/broker/execution.py tests/unit/test_execution.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c800e7188320a252e5519624ec01