### PR TITLE
Await trade.statusEvent directly

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -58,8 +58,7 @@ async def submit_batch(
             status = getattr(trade.orderStatus, "status", "")
             if status in terminal:
                 return status
-            await trade.statusEvent.wait()
-            trade.statusEvent.clear()
+            await trade.statusEvent
 
     async def _submit_one(st: Trade) -> dict[str, Any]:
         contract = Stock(st.symbol, "SMART", "USD")

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -10,13 +10,22 @@ from src.broker.ibkr_client import IBKRError
 from src.core.sizing import SizedTrade
 
 
+class AutoEvent(asyncio.Event):
+    async def _wait(self) -> None:
+        await super().wait()
+        self.clear()
+
+    def __await__(self):  # type: ignore[override]
+        return self._wait().__await__()
+
+
 class DummyTrade:
     def __init__(self, status="Submitted", filled=0.0):
         self.orderStatus = SimpleNamespace(
             status=status, filled=filled, avgFillPrice=0.0
         )
         self.order = SimpleNamespace(orderId=1)
-        self.statusEvent = asyncio.Event()
+        self.statusEvent = AutoEvent()
 
 
 class FakeClient:


### PR DESCRIPTION
## Summary
- await trade.statusEvent directly in execution loop and drop manual clear
- update tests with auto-resetting status events

## Testing
- `pre-commit run --files src/broker/execution.py tests/unit/test_execution.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c9c24f5483208767046bca29ae3a