### PR TITLE
Use awaitable events in execution tests

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -59,6 +59,7 @@ async def submit_batch(
             if status in terminal:
                 return status
             await trade.statusEvent
+            trade.statusEvent.clear()
 
     async def _submit_one(st: Trade) -> dict[str, Any]:
         contract = Stock(st.symbol, "SMART", "USD")

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -10,13 +10,9 @@ from src.broker.ibkr_client import IBKRError
 from src.core.sizing import SizedTrade
 
 
-class AutoEvent(asyncio.Event):
-    async def _wait(self) -> None:
-        await super().wait()
-        self.clear()
-
+class AwaitableEvent(asyncio.Event):
     def __await__(self):  # type: ignore[override]
-        return self._wait().__await__()
+        return self.wait().__await__()
 
 
 class DummyTrade:
@@ -25,7 +21,7 @@ class DummyTrade:
             status=status, filled=filled, avgFillPrice=0.0
         )
         self.order = SimpleNamespace(orderId=1)
-        self.statusEvent = AutoEvent()
+        self.statusEvent = AwaitableEvent()
 
 
 class FakeClient:


### PR DESCRIPTION
## Summary
- introduce AwaitableEvent helper for tests
- clear status events after waiting in `submit_batch`

## Testing
- `PYTHONPATH=$PWD pytest tests/unit/test_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7ca982b0c832093a9f5cde01b1577