### PR TITLE
Add logging and reporting to rebalance workflow

### DIFF
--- a/src/io/reporting.py
+++ b/src/io/reporting.py
@@ -20,7 +20,7 @@ def _format_ts(ts: datetime) -> str:
     return ts.strftime("%Y%m%d_%H%M%S")
 
 
-def setup_logging(report_dir: Path, level: str, ts: datetime) -> Path:
+def setup_logging(report_dir: Path, level: str, ts: datetime | str) -> Path:
     """Configure root logging to a timestamped file.
 
     Parameters
@@ -40,7 +40,8 @@ def setup_logging(report_dir: Path, level: str, ts: datetime) -> Path:
     """
 
     report_dir.mkdir(parents=True, exist_ok=True)
-    log_path = report_dir / f"rebalance_{_format_ts(ts)}.log"
+    ts_str = ts if isinstance(ts, str) else _format_ts(ts)
+    log_path = report_dir / f"rebalance_{ts_str}.log"
     numeric_level = getattr(logging, level.upper(), logging.INFO)
     logging.basicConfig(
         filename=str(log_path),

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -19,6 +19,8 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch) -> dict:
         ibkr=SimpleNamespace(host="h", port=1, client_id=1, account_id="a"),
         models=SimpleNamespace(smurf=0.5, badass=0.3, gltr=0.2),
         pricing=SimpleNamespace(price_source="last", fallback_to_snapshot=True),
+        execution=SimpleNamespace(order_type="MKT", algo_preference="adaptive"),
+        io=SimpleNamespace(report_dir="reports", log_level="INFO"),
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _: cfg)
 

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -16,11 +16,17 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch):
         models=SimpleNamespace(smurf=0.5, badass=0.3, gltr=0.2),
         pricing=SimpleNamespace(price_source="last", fallback_to_snapshot=True),
         rebalance=SimpleNamespace(
-            min_order_usd=1, allow_fractional=True, cash_buffer_pct=0, max_leverage=2
+            min_order_usd=1,
+            allow_fractional=True,
+            cash_buffer_pct=0,
+            max_leverage=2,
         ),
         execution=SimpleNamespace(
-            algo_preference="adaptive", fallback_plain_market=False
+            order_type="MKT",
+            algo_preference="adaptive",
+            fallback_plain_market=False,
         ),
+        io=SimpleNamespace(report_dir="reports", log_level="INFO"),
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _: cfg)
 


### PR DESCRIPTION
## Summary
- initialize timestamped logging and replace milestone prints with log calls
- generate pre- and post-trade reports with exposure metrics and execution results
- update tests for new configuration requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8449f5f648320bc392aefacda3e58