### PR TITLE
Capture fill metadata and report fill details

### DIFF
--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -65,6 +65,10 @@ def test_rejected_order_returns_status(monkeypatch):
             "status": "Rejected",
             "filled": 0.0,
             "avg_fill_price": 0.0,
+            "fill_qty": 0.0,
+            "fill_price": 0.0,
+            "fill_time": None,
+            "commission": 0.0,
         }
     ]
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -97,7 +97,16 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
         assert float(row[field]) == pytest.approx(expected_values[field])
 
     results = [
-        {"symbol": "AAA", "status": "Filled", "filled": 10.0, "avg_fill_price": 100.0}
+        {
+            "symbol": "AAA",
+            "status": "Filled",
+            "filled": 10.0,
+            "avg_fill_price": 100.0,
+            "fill_qty": 10.0,
+            "fill_price": 100.0,
+            "fill_time": ts.isoformat(),
+            "commission": 1.23,
+        }
     ]
 
     post_path = write_post_trade_report(
@@ -114,7 +123,15 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
         cfg,
     )
 
-    expected_post_fields = expected_pre_fields + ["status", "error", "notes"]
+    expected_post_fields = expected_pre_fields + [
+        "fill_qty",
+        "fill_price",
+        "fill_timestamp",
+        "commission",
+        "status",
+        "error",
+        "notes",
+    ]
 
     with post_path.open() as f:
         reader = csv.DictReader(f)
@@ -123,6 +140,10 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
 
     for field in numeric_fields:
         assert float(row[field]) == pytest.approx(expected_values[field])
+    assert float(row["fill_qty"]) == pytest.approx(10.0)
+    assert float(row["fill_price"]) == pytest.approx(100.0)
+    assert row["fill_timestamp"] == ts.isoformat()
+    assert float(row["commission"]) == pytest.approx(1.23)
 
     messages = [rec.message for rec in caplog.records]
     assert f"Pre-trade report written to {pre_path}" in messages


### PR DESCRIPTION
## Summary
- record detailed fill info (quantity, price, timestamp, commission) for each execution
- add new fill-related columns to post-trade CSV reports and update reporting logic
- handle enriched execution results in rebalance workflow and tests

## Testing
- `pre-commit run --files src/broker/execution.py src/io/reporting.py src/rebalance.py tests/unit/test_reporting.py tests/unit/test_execution.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b84a644d1c8320b26cb4b98fa916da