### PR TITLE
Handle placeholder commission reports

### DIFF
--- a/src/io/reporting.py
+++ b/src/io/reporting.py
@@ -172,6 +172,7 @@ def write_post_trade_report(
         "fill_price",
         "fill_timestamp",
         "commission",
+        "commission_placeholder",
         "status",
         "error",
         "notes",
@@ -217,6 +218,7 @@ def write_post_trade_report(
                 fill_ts = str(fill_ts_any)
 
             commission = res.get("commission", 0.0)
+            commission_placeholder = res.get("commission_placeholder", False)
 
             value = fill_qty * fill_price
             writer.writerow(
@@ -243,6 +245,7 @@ def write_post_trade_report(
                     "fill_price": fill_price,
                     "fill_timestamp": fill_ts or "",
                     "commission": commission,
+                    "commission_placeholder": commission_placeholder,
                     "status": res.get("status", ""),
                     "error": res.get("error", ""),
                     "notes": res.get("notes", ""),

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -128,6 +128,7 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
         "fill_price",
         "fill_timestamp",
         "commission",
+        "commission_placeholder",
         "status",
         "error",
         "notes",
@@ -144,6 +145,7 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
     assert float(row["fill_price"]) == pytest.approx(100.0)
     assert row["fill_timestamp"] == ts.isoformat()
     assert float(row["commission"]) == pytest.approx(1.23)
+    assert row["commission_placeholder"] == "False"
 
     messages = [rec.message for rec in caplog.records]
     assert f"Pre-trade report written to {pre_path}" in messages


### PR DESCRIPTION
## Summary
- Treat commission reports as complete only when execId or commission is present and flag placeholders
- Warn and flag fills with placeholder commission reports during execution
- Surface commission placeholder flag in post-trade reports and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87097b8588320be52badba72d2514