### PR TITLE
Format execution helpers and tests with Black

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -128,10 +128,7 @@ async def submit_batch(
                 cr = getattr(f, "commissionReport", None)
                 if cr is None:
                     return False
-                return bool(
-                    getattr(cr, "execId", "")
-                    or getattr(cr, "commission", 0.0)
-                )
+                return bool(getattr(cr, "execId", "") or getattr(cr, "commission", 0.0))
 
             try:
                 fills = getattr(ib_trade, "fills", []) or []

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -309,7 +309,9 @@ def test_placeholder_commission_logs_warning(monkeypatch, caplog):
     def fake_place(*_a, **_k):
         trade = DummyTradeWithCommission(status="Filled", filled=5.0)
         fill = SimpleNamespace(
-            execution=SimpleNamespace(time=datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC"))),
+            execution=SimpleNamespace(
+                time=datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC"))
+            ),
             commissionReport=SimpleNamespace(execId="", commission=0.0),
         )
         trade.fills.append(fill)


### PR DESCRIPTION
## Summary
- Apply Black formatting to `execution` module and its unit tests for consistent style

## Testing
- `black --check src/broker/execution.py tests/unit/test_execution.py`
- `PYTHONPATH=. pytest tests/unit/test_execution.py`


------
https://chatgpt.com/codex/tasks/task_e_68b87654726c8320957a5af1b297a005