### PR TITLE
Fetch prices only for trade symbols

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -100,13 +100,16 @@ async def _run(args: argparse.Namespace) -> None:
         prioritized = prioritize_by_drift(drifts, cfg)
 
         trade_symbols = {
-            d.symbol for d in prioritized if d.symbol != "CASH" and d.action in ("BUY", "SELL")
+            d.symbol
+            for d in prioritized
+            if d.symbol != "CASH" and d.action in ("BUY", "SELL")
         }
 
         print(f"[blue]Fetching prices for {len(trade_symbols)} trade symbols[/blue]")
         logging.info("Fetching prices for %d symbols", len(trade_symbols))
         tasks = [
-            asyncio.create_task(_fetch_price(client._ib, sym, cfg)) for sym in trade_symbols
+            asyncio.create_task(_fetch_price(client._ib, sym, cfg))
+            for sym in trade_symbols
         ]
         for idx, task in enumerate(asyncio.as_completed(tasks), 1):
             try:
@@ -124,7 +127,7 @@ async def _run(args: argparse.Namespace) -> None:
         prices = {sym: prices[sym] for sym in trade_symbols}
     finally:
         await client.disconnect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
-    
+
     print("[blue]Sizing orders[/blue]")
     logging.info("Sizing orders")
     trades, post_gross_exposure, post_leverage = size_orders(

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -36,8 +36,8 @@ class DummyIBKRClient:
     async def snapshot(self, account_id: str) -> dict:  # noqa: ARG002
         return {
             "positions": [
-                {"symbol": "SPY", "position": 10},
-                {"symbol": "IAU", "position": 5},
+                {"symbol": "SPY", "position": 10, "avg_cost": 100.0},
+                {"symbol": "IAU", "position": 5, "avg_cost": 100.0},
             ],
             "cash": 1000.0,
             "net_liq": 2500.0,

--- a/tests/integration/test_rebalance_dry_run.py
+++ b/tests/integration/test_rebalance_dry_run.py
@@ -32,8 +32,8 @@ class DummyIBKRClient:
     async def snapshot(self, account_id: str) -> dict:  # noqa: ARG002
         return {
             "positions": [
-                {"symbol": "SPY", "position": 10},
-                {"symbol": "IAU", "position": 5},
+                {"symbol": "SPY", "position": 10, "avg_cost": 100.0},
+                {"symbol": "IAU", "position": 5, "avg_cost": 100.0},
             ],
             "cash": 1000.0,
             "net_liq": 2500.0,

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -92,7 +92,11 @@ def test_run_fetches_prices_only_for_trades(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     args = argparse.Namespace(
-        config="cfg", csv="csv", dry_run=True, yes=False, read_only=False,
+        config="cfg",
+        csv="csv",
+        dry_run=True,
+        yes=False,
+        read_only=False,
     )
     asyncio.run(rebalance._run(args))
 
@@ -113,7 +117,11 @@ def test_run_aborts_when_trade_price_unavailable(
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     args = argparse.Namespace(
-        config="cfg", csv="csv", dry_run=True, yes=False, read_only=False,
+        config="cfg",
+        csv="csv",
+        dry_run=True,
+        yes=False,
+        read_only=False,
     )
     with pytest.raises(SystemExit):
         asyncio.run(rebalance._run(args))
@@ -123,4 +131,3 @@ def test_run_aborts_when_trade_price_unavailable(
     assert pre == {"AAA": 10.0}
     assert fetched == ["AAA"]
     assert sizing == {}
-


### PR DESCRIPTION
## Summary
- Seed price map with snapshot values so drift can be computed without live requests
- Fetch live prices only for symbols requiring BUY/SELL actions and pass trimmed map downstream
- Revise tests to expect trade-symbol-only fetches and handle non-traded symbols

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88e014c0c8320aaeeb66d2437bda7