### PR TITLE
Preserve estimated prices in post-trade report

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -201,6 +201,7 @@ async def _run(args: argparse.Namespace) -> None:
 
     cash_after = current["CASH"]
     positions = current.copy()
+    prices_before = prices.copy()
     results_by_symbol = {r.get("symbol"): r for r in results}
     for trade in trades:
         res = results_by_symbol.get(trade.symbol, {})
@@ -229,6 +230,7 @@ async def _run(args: argparse.Namespace) -> None:
         drifts,
         trades,
         results,
+        prices_before,
         pre_gross_exposure,
         pre_leverage,
         post_gross_exposure_actual,

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -245,6 +245,7 @@ def test_delayed_commission_reports_recorded(monkeypatch, tmp_path):
         [drift],
         [sized_trade],
         res,
+        {"AAA": 100.0},
         9000.0,
         0.9,
         10000.0,

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -100,10 +100,10 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
         {
             "symbol": "AAA",
             "status": "Filled",
-            "filled": 10.0,
-            "avg_fill_price": 100.0,
-            "fill_qty": 10.0,
-            "fill_price": 100.0,
+            "filled": 8.0,
+            "avg_fill_price": 110.0,
+            "fill_qty": 8.0,
+            "fill_price": 110.0,
             "fill_time": ts.isoformat(),
             "commission": 1.23,
         }
@@ -116,6 +116,7 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
         [drift],
         trades,
         results,
+        prices,
         9000.0,
         0.9,
         10000.0,
@@ -141,8 +142,8 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
 
     for field in numeric_fields:
         assert float(row[field]) == pytest.approx(expected_values[field])
-    assert float(row["fill_qty"]) == pytest.approx(10.0)
-    assert float(row["fill_price"]) == pytest.approx(100.0)
+    assert float(row["fill_qty"]) == pytest.approx(8.0)
+    assert float(row["fill_price"]) == pytest.approx(110.0)
     assert row["fill_timestamp"] == ts.isoformat()
     assert float(row["commission"]) == pytest.approx(1.23)
     assert row["commission_placeholder"] == "False"


### PR DESCRIPTION
## Summary
- keep estimated prices in post-trade CSV consistent with pre-trade report
- retain original prices before fills when writing post-trade report
- extend tests to cover differing fill prices and quantities

## Testing
- `pre-commit run --files src/io/reporting.py src/rebalance.py tests/unit/test_execution.py tests/unit/test_reporting.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b88df8f8248320b4b115a97f3ee935