### PR TITLE
Add exponential backoff and centralize broker error handling

### DIFF
--- a/src/broker/errors.py
+++ b/src/broker/errors.py
@@ -1,0 +1,7 @@
+"""Shared broker exception types."""
+
+from __future__ import annotations
+
+
+class IBKRError(Exception):
+    """Exception raised for IBKR client and order errors."""

--- a/src/broker/utils.py
+++ b/src/broker/utils.py
@@ -1,0 +1,60 @@
+"""Utility helpers for broker operations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, TypeVar, Union
+
+from .errors import IBKRError
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+Func = Callable[..., Union[T, Awaitable[T]]]
+
+
+async def retry_async(
+    func: Func,
+    *args: Any,
+    retries: int = 3,
+    base_delay: float = 0.5,
+    action: str = "operation",
+) -> T:
+    """Execute *func* with exponential backoff retry.
+
+    Parameters
+    ----------
+    func:
+        Callable that may be synchronous or asynchronous.
+    retries:
+        Total number of attempts before giving up.
+    base_delay:
+        Initial delay between attempts in seconds; doubles each retry.
+    action:
+        Descriptive name used in log and error messages.
+    """
+
+    for attempt in range(1, retries + 1):
+        try:
+            result = func(*args)
+            if asyncio.iscoroutine(result):
+                result = await result
+            return result
+        except Exception as exc:  # pragma: no cover - network errors
+            if attempt == retries:
+                log.error("%s failed after %d attempts: %s", action, attempt, exc)
+                raise IBKRError(
+                    f"{action} failed after {attempt} attempts: {exc}"
+                ) from exc
+            delay = base_delay * (2 ** (attempt - 1))
+            log.warning(
+                "%s attempt %d/%d failed: %s; retrying in %.1fs",
+                action.capitalize(),
+                attempt,
+                retries,
+                exc,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    raise IBKRError(f"{action} failed")  # pragma: no cover - defensive

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -11,8 +11,9 @@ from pathlib import Path
 
 from rich import print
 
+from src.broker.errors import IBKRError
 from src.broker.execution import submit_batch
-from src.broker.ibkr_client import IBKRError, IBKRClient
+from src.broker.ibkr_client import IBKRClient
 from src.core.drift import compute_drift, prioritize_by_drift
 from src.core.preview import render as render_preview
 from src.core.pricing import PricingError, get_price

--- a/src/snapshot.py
+++ b/src/snapshot.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from rich import print
 
-from src.broker.ibkr_client import IBKRClient, IBKRError
+from src.broker.errors import IBKRError
+from src.broker.ibkr_client import IBKRClient
 from src.io.config_loader import ConfigError, load_config
 
 


### PR DESCRIPTION
## Summary
- add shared `IBKRError` and `retry_async` helper for exponential backoff
- refactor IBKR client connection/disconnection and order submission to use backoff
- expand tests for retry exhaustion and concise error messages

## Testing
- `pre-commit run --files src/broker/errors.py src/broker/utils.py src/broker/ibkr_client.py src/broker/execution.py src/snapshot.py src/rebalance.py tests/unit/test_ibkr_client.py tests/unit/test_execution.py`
- `pytest tests/unit/test_ibkr_client.py tests/unit/test_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8af7ed9148320b32281a625dd6fe1