### PR TITLE
Clarify and document sample configuration and portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ $env:PYTHONPATH = "."
 pytest -q -m "not integration"
 ```
 
+### Customize sample files
+
+The repository includes example `config/settings.ini` and `data/portfolios.csv`.
+Make copies of these files outside version control and edit them with your own
+IBKR host, account ID, and target weights:
+
+```bash
+cp config/settings.ini my_settings.ini
+cp data/portfolios.csv my_portfolios.csv
+```
+
+Blank cells in the CSV represent 0% allocations. Use the copied files via
+`--config my_settings.ini --csv my_portfolios.csv` when running the tools.
+
 ## Usage
 
 ### Validate configuration

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -1,12 +1,13 @@
+; Sample configuration for IBKR connection
 [ibkr]
-; Hostname or IP for IBKR Gateway/TWS (e.g., 127.0.0.1)
+; Hostname or IP for your IBKR Gateway/TWS (usually 127.0.0.1)
 host = 127.0.0.1
 ; Gateway/TWS port (4002 paper, 4001 live)
 port = 4002
-; Unique API client ID (non-negative integer)
-client_id = 42
-; IBKR account ID (U123456 live or DU123456 paper)
-account_id = DUA071544
+; Unique API client ID (any non-negative integer not used by other sessions)
+client_id = 1
+; IBKR account ID (e.g., DU123456 for paper or U123456 for live)
+account_id = DU123456
 ; true blocks trading, false enables order placement
 read_only = false
 

--- a/data/portfolios.csv
+++ b/data/portfolios.csv
@@ -1,3 +1,5 @@
+# Example portfolios with target weights for each model.
+# Percentages may include a trailing %, and blank cells mean a 0% allocation.
 ETF,SMURF,BADASS,GLTR
 BLOK,,0%,
 IBIT,,0%,

--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -100,7 +100,11 @@ async def load_portfolios(
     """
 
     with path.open(newline="") as fh:
-        reader = csv.DictReader(fh)
+        # Allow top-of-file comments or blank lines in sample CSVs.
+        filtered = (
+            line for line in fh if line.strip() and not line.lstrip().startswith("#")
+        )
+        reader = csv.DictReader(filtered)
         fieldnames = reader.fieldnames
         if fieldnames is None:
             raise PortfolioCSVError("Missing header")


### PR DESCRIPTION
## Summary
- replace sensitive account details in `config/settings.ini` with generic examples and clearer comments
- add descriptive comments to `data/portfolios.csv` and teach loader to skip comment lines
- explain in `README.md` how to copy and customize the sample config and portfolio files

## Testing
- `pre-commit run --files README.md config/settings.ini data/portfolios.csv src/io/portfolio_csv.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b31111b483208d2be04b02da6bea