### PR TITLE
Fix typing for retry_async

### DIFF
--- a/src/broker/utils.py
+++ b/src/broker/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, TypeVar, Union
+from typing import Any, Awaitable, Callable, TypeVar, Union, cast
 
 from .errors import IBKRError
 
@@ -39,8 +39,8 @@ async def retry_async(
         try:
             result = func(*args)
             if asyncio.iscoroutine(result):
-                result = await result
-            return result
+                result = await cast(Awaitable[T], result)
+            return cast(T, result)
         except Exception as exc:  # pragma: no cover - network errors
             if attempt == retries:
                 log.error("%s failed after %d attempts: %s", action, attempt, exc)


### PR DESCRIPTION
## Summary
- ensure `retry_async` returns consistent type by casting awaited results

## Testing
- `pytest`
- `mypy src`
- `ruff check src/broker/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c507a50483209e6b8517e0756142