### PR TITLE
Refine account confirm_mode formatting

### DIFF
--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -148,9 +148,22 @@ def load_config(path: Path) -> AppConfig:
                 seen.add(s)
         if not ids:
             raise ConfigError("[accounts] ids must be non-empty")
-        confirm_mode = cp.get("accounts", "confirm_mode", fallback="per_account").strip().lower()
+        confirm_mode = (
+            cp.get(
+                "accounts",
+                "confirm_mode",
+                fallback="per_account",
+            )
+            .strip()
+            .lower()
+        )
         if confirm_mode not in {"per_account", "global"}:
-            raise ConfigError("[accounts] confirm_mode must be 'per_account' or 'global'")
+            # fmt: off
+            raise ConfigError(
+                "[accounts] confirm_mode must be "
+                "'per_account' or 'global'"
+            )
+            # fmt: on
         accounts = Accounts(ids=ids, confirm_mode=confirm_mode)
         account_id = ids[0]
     else:


### PR DESCRIPTION
## Summary
- split accounts section's confirm_mode assignment across multiple lines
- wrap confirm_mode validation error for readability

## Testing
- `black src/io/config_loader.py`
- `black --check src/io/config_loader.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9baf477d4832081a507a2203f520d