### PR TITLE
Propagate account IDs through rebalance helpers

### DIFF
--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Mapping
+import logging
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,7 @@ class Drift:
 
 
 def compute_drift(
+    account_id: str,
     current: Mapping[str, float],
     targets: Mapping[str, float],
     prices: Mapping[str, float],
@@ -53,6 +55,8 @@ def compute_drift(
 
     Parameters
     ----------
+    account_id:
+        Account identifier used for logging context.
     current:
         Mapping of symbols to share quantities.  ``"CASH"`` represents the
         dollar value of cash holdings.
@@ -73,6 +77,8 @@ def compute_drift(
         ``targets``.  The list is sorted alphabetically by symbol to ensure
         deterministic output.
     """
+
+    logging.debug("Computing drift for account %s", account_id)
 
     # Determine current weights for all held symbols.
     values: dict[str, float] = {}
@@ -163,11 +169,13 @@ def compute_drift(
     return drifts
 
 
-def prioritize_by_drift(drifts: list[Drift], cfg: Any) -> list[Drift]:
+def prioritize_by_drift(account_id: str, drifts: list[Drift], cfg: Any) -> list[Drift]:
     """Filter and sort drifts by dollar magnitude.
 
     Parameters
     ----------
+    account_id:
+        Account identifier used for logging context.
     drifts:
         Drift records to evaluate.
     cfg:
@@ -179,6 +187,8 @@ def prioritize_by_drift(drifts: list[Drift], cfg: Any) -> list[Drift]:
         Drifts whose absolute dollar value exceeds ``min_order_usd``,
         sorted from largest to smallest by absolute drift.
     """
+
+    logging.debug("Prioritizing drifts for account %s", account_id)
 
     try:
         min_order = cfg.rebalance.min_order_usd  # type: ignore[attr-defined]

--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -12,12 +12,14 @@ from io import StringIO
 from rich import box
 from rich.console import Console
 from rich.table import Table
+import logging
 
 from .drift import Drift
 from .sizing import SizedTrade
 
 
 def render(
+    account_id: str,
     plan: list[Drift],
     trades: list[SizedTrade] | None = None,
     pre_gross_exposure: float = 0.0,
@@ -29,6 +31,8 @@ def render(
 
     Parameters
     ----------
+    account_id:
+        Account identifier used for logging context.
     plan:
         Drift records, typically already filtered and prioritised.
     trades:
@@ -48,6 +52,8 @@ def render(
     str
         Table rendering of the drift information followed by a batch summary.
     """
+
+    logging.debug("Rendering preview for account %s", account_id)
 
     # ``Rich``'s default table box style has changed across releases. Some
     # versions render with the heavy box drawing characters we expect in the

--- a/src/core/sizing.py
+++ b/src/core/sizing.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from typing import Any, Mapping
+import logging
 
 from .drift import Drift
 
@@ -50,6 +51,7 @@ def _extract_cfg(cfg: Any) -> tuple[int, bool, str, float | None, float | None, 
 
 
 def size_orders(
+    account_id: str,
     drifts: list[Drift],
     prices: Mapping[str, float],
     cash: float,
@@ -60,6 +62,8 @@ def size_orders(
 
     Parameters
     ----------
+    account_id:
+        Account identifier used for logging context.
     drifts:
         Prioritised drift records.
     prices:
@@ -77,6 +81,8 @@ def size_orders(
         A list of :class:`SizedTrade` objects along with the projected gross
         exposure and leverage after applying the trades.
     """
+
+    logging.debug("Sizing orders for account %s", account_id)
 
     (
         min_order_usd,

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -21,7 +21,7 @@ def test_compute_drift_normalizes_and_combines_targets() -> None:
     prices = {"AAA": 100.0, "BBB": 100.0}
     net_liq = 6000.0  # 10*100 + 5000
 
-    drifts = compute_drift(current, targets, prices, net_liq, cfg=None)
+    drifts = compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
     by_symbol = {d.symbol: d for d in drifts}
 
     assert len(drifts) == 3
@@ -72,7 +72,7 @@ def test_compute_drift_respects_cash_buffer(
     net_liq = 6000.0
     cfg = SimpleNamespace(rebalance=reb_cfg)
 
-    drifts = compute_drift(current, targets, prices, net_liq, cfg)
+    drifts = compute_drift("ACCT", current, targets, prices, net_liq, cfg)
     by_symbol = {d.symbol: d for d in drifts}
 
     aaa = by_symbol["AAA"]
@@ -98,7 +98,7 @@ def test_compute_drift_defaults_missing_targets_to_zero() -> None:
     prices = {"AAA": 100.0, "CCC": 10.0, "BBB": 100.0}
     net_liq = 600.0  # 5*100 + 10*10
 
-    drifts = compute_drift(current, targets, prices, net_liq, cfg=None)
+    drifts = compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
     by_symbol = {d.symbol: d for d in drifts}
 
     # Ensure "CCC" (missing from targets) defaults to 0 target weight
@@ -170,7 +170,7 @@ def test_per_holding_mode_triggers_symbols_and_skips_small_drifts(
 ) -> None:
     cfg = cfg_factory("per_holding", per_band=300)
     drifts = compute_drift(
-        per_holding_current, per_holding_targets, sample_prices, 100.0, cfg
+        "ACCT", per_holding_current, per_holding_targets, sample_prices, 100.0, cfg
     )
     symbols = [d.symbol for d in drifts]
     assert symbols == ["AAA", "BBB"]
@@ -187,7 +187,7 @@ def test_total_drift_mode_selects_largest_until_band(
     cfg_factory,
 ) -> None:
     cfg = cfg_factory("total_drift", total_band=500)
-    drifts = compute_drift(total_current, total_targets, sample_prices, 100.0, cfg)
+    drifts = compute_drift("ACCT", total_current, total_targets, sample_prices, 100.0, cfg)
     assert [d.symbol for d in drifts] == ["AAA", "BBB"]
     by_symbol = {d.symbol: d for d in drifts}
     assert by_symbol["AAA"].action == "SELL"
@@ -201,7 +201,7 @@ def test_prioritize_by_drift_filters_and_sorts(cfg_factory) -> None:
         Drift("CCC", 0.0, 0.0, 0.0, 150.0, "BUY"),
     ]
     cfg = cfg_factory(min_order=100)
-    prioritized = prioritize_by_drift(drifts, cfg)
+    prioritized = prioritize_by_drift("ACCT", drifts, cfg)
     assert [d.symbol for d in prioritized] == ["BBB", "CCC"]
     assert prioritized[0].drift_usd == -200.0
     assert prioritized[1].drift_usd == 150.0
@@ -212,7 +212,7 @@ def test_compute_drift_zero_drift_returns_hold() -> None:
     targets = {"AAA": 100.0}
     prices = {"AAA": 1.0}
     net_liq = 5.0
-    drifts = compute_drift(current, targets, prices, net_liq, cfg=None)
+    drifts = compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
     assert len(drifts) == 1
     d = drifts[0]
     assert d.drift_pct == pytest.approx(0.0)

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -36,8 +36,8 @@ def test_render_sorted_and_filtered() -> None:
     ]
     cfg = _cfg(100)
 
-    prioritized = prioritize_by_drift(drifts, cfg)
-    table = render(prioritized, [], 0.0, 0.0, 0.0, 0.0)
+    prioritized = prioritize_by_drift("ACCT", drifts, cfg)
+    table = render("ACCT", prioritized, [], 0.0, 0.0, 0.0, 0.0)
 
     assert "Drift %" in table
     assert "BBB" not in table
@@ -49,11 +49,11 @@ def test_render_shows_quantities_and_notional() -> None:
     prices = {"AAA": 25.0}
     cfg = _cfg(1)
 
-    prioritized = prioritize_by_drift(drifts, cfg)
+    prioritized = prioritize_by_drift("ACCT", drifts, cfg)
     trades, post_exp, post_lev = size_orders(
-        prioritized, prices, cash=100.0, net_liq=100.0, cfg=cfg
+        "ACCT", prioritized, prices, cash=100.0, net_liq=100.0, cfg=cfg
     )
-    table = render(prioritized, trades, 100.0, 1.0, post_exp, post_lev)
+    table = render("ACCT", prioritized, trades, 100.0, 1.0, post_exp, post_lev)
 
     assert "Qty" in table
     assert "Notional" in table
@@ -78,6 +78,7 @@ def test_render_batch_summary() -> None:
     post_exp = pre_exp + gross_buy - gross_sell
     post_lev = post_exp / (pre_exp / pre_lev)
     table = render(
+        "ACCT",
         drifts,
         trades,
         pre_gross_exposure=pre_exp,

--- a/tests/unit/test_prioritize.py
+++ b/tests/unit/test_prioritize.py
@@ -19,7 +19,7 @@ def test_prioritize_filters_and_sorts_by_abs_drift_usd() -> None:
     ]
     cfg = _cfg(100)
 
-    prioritized = prioritize_by_drift(drifts, cfg)
+    prioritized = prioritize_by_drift("ACCT", drifts, cfg)
 
     assert [d.symbol for d in prioritized] == ["CCC", "AAA"]
 
@@ -31,6 +31,6 @@ def test_prioritize_retains_all_when_threshold_zero() -> None:
     ]
     cfg = _cfg(0)
 
-    prioritized = prioritize_by_drift(drifts, cfg)
+    prioritized = prioritize_by_drift("ACCT", drifts, cfg)
 
     assert [d.symbol for d in prioritized] == ["AAA", "BBB"]

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -63,7 +63,7 @@ def _setup_common(
     captured_fetch: list[str] = []
     captured_sizing: dict[str, float] = {}
 
-    def fake_compute_drift(current, targets, prices, net_liq, cfg):
+    def fake_compute_drift(account_id, current, targets, prices, net_liq, cfg):
         captured_pre.update(prices)
         return [
             Drift("AAA", 0, 0, -10.0, -10.0, "BUY"),
@@ -74,10 +74,10 @@ def _setup_common(
     monkeypatch.setattr(
         rebalance,
         "prioritize_by_drift",
-        lambda drifts, cfg: [d for d in drifts if d.action != "HOLD"],
+        lambda account_id, drifts, cfg: [d for d in drifts if d.action != "HOLD"],
     )
 
-    def fake_size_orders(prioritized, prices, cash, net_liq, cfg):
+    def fake_size_orders(account_id, prioritized, prices, cash, net_liq, cfg):
         captured_sizing.update(prices)
         return [], [], []
 

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -60,11 +60,13 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
 
     monkeypatch.setattr(rebalance, "compute_drift", lambda *a, **k: [])
-    monkeypatch.setattr(rebalance, "prioritize_by_drift", lambda drifts, cfg: [])
+    monkeypatch.setattr(
+        rebalance, "prioritize_by_drift", lambda account_id, drifts, cfg: []
+    )
     monkeypatch.setattr(
         rebalance,
         "size_orders",
-        lambda prioritized, prices, cash, net_liq, cfg: (
+        lambda account_id, prioritized, prices, cash, net_liq, cfg: (
             [SizedTrade("AAA", "BUY", 5.0, 50.0)],
             0.0,
             0.0,

--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -72,7 +72,7 @@ def test_greedy_fill_under_limited_cash(
     )
 
     trades, gross, lev = size_orders(
-        drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
+        "ACCT", drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
     )
 
     qty = 100.0 / prices["AAA"]  # all available cash goes to highest priority
@@ -92,7 +92,9 @@ def test_residual_cash_distributed_proportionally() -> None:
     prices = {"AAA": 10.0, "BBB": 20.0, "CCC": 5.0}
     cfg = _cfg()
 
-    trades, gross, lev = size_orders(drifts, prices, cash=0.0, net_liq=net_liq, cfg=cfg)
+    trades, gross, lev = size_orders(
+        "ACCT", drifts, prices, cash=0.0, net_liq=net_liq, cfg=cfg
+    )
 
     assert sorted(trades, key=lambda t: t.symbol) == [
         SizedTrade("AAA", "BUY", 10.0, 100.0),
@@ -110,7 +112,7 @@ def test_leverage_scaled_when_exceeding_max() -> None:
     cfg = _cfg(max_leverage=0.85)
 
     trades, gross, lev = size_orders(
-        drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
+        "ACCT", drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
     )
 
     assert trades == [SizedTrade("AAA", "BUY", 5.0, 50.0)]
@@ -125,7 +127,7 @@ def test_rounds_and_drops_orders_below_min() -> None:
     cfg = _cfg(min_order_usd=50, allow_fractional=False)
 
     trades, gross, lev = size_orders(
-        drifts, prices, cash=600.0, net_liq=net_liq, cfg=cfg
+        "ACCT", drifts, prices, cash=600.0, net_liq=net_liq, cfg=cfg
     )
 
     assert trades == []
@@ -141,13 +143,13 @@ def test_rejects_non_finite_price_or_quantity() -> None:
     drifts = [_drift("AAA", -100.0, net_liq)]
     prices = {"AAA": math.nan}
     with pytest.raises(ValueError):
-        size_orders(drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg)
+        size_orders("ACCT", drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg)
 
     # Non-finite quantity
     bad_drift = Drift("BBB", 0.0, 0.0, 0.0, math.nan, "BUY")
     prices = {"BBB": 10.0}
     with pytest.raises(ValueError):
-        size_orders([bad_drift], prices, cash=200.0, net_liq=net_liq, cfg=cfg)
+        size_orders("ACCT", [bad_drift], prices, cash=200.0, net_liq=net_liq, cfg=cfg)
 
 
 def test_duplicate_symbols_are_merged() -> None:
@@ -158,7 +160,7 @@ def test_duplicate_symbols_are_merged() -> None:
     cfg = _cfg(allow_fractional=True)
 
     trades, _gross, _lev = size_orders(
-        drifts, prices, cash=500.0, net_liq=net_liq, cfg=cfg
+        "ACCT", drifts, prices, cash=500.0, net_liq=net_liq, cfg=cfg
     )
 
     assert trades == [SizedTrade("AAA", "BUY", 20.0, 200.0)]


### PR DESCRIPTION
## Summary
- Pass account ID through drift computation, prioritization, sizing, preview, and submission steps
- Add logging context for account-specific operations
- Adjust unit tests for new account-aware helper signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9c0a0223483208052a3441b64a940