### PR TITLE
Add global confirmation mode for rebalancing

### DIFF
--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -122,3 +122,80 @@ def test_yes_skips_prompt(
     captured = capsys.readouterr().out
     assert "Proceed? [y/N]" not in captured
     assert "Submitting batch market orders" in captured
+
+
+def test_prompt_global(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Global confirmation prompts once for all accounts."""
+
+    monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
+    monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
+
+    prompts: list[str] = []
+
+    def fake_input(prompt: str) -> str:  # pragma: no cover - trivial
+        prompts.append(prompt)
+        print(prompt, end="")
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    args = Namespace(
+        config="config/settings.ini",
+        csv="data/portfolios.csv",
+        dry_run=False,
+        yes=False,
+        read_only=False,
+        confirm_mode="global",
+    )
+
+    asyncio.run(rebalance._run(args))
+
+    captured = capsys.readouterr().out
+    assert prompts == ["Proceed? [y/N]: "]
+    assert "Aborted by user." in captured
+
+
+def test_yes_skips_prompt_global(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--yes skips the global confirmation prompt."""
+
+    monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
+    monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
+    monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
+
+    def fail_input(*args, **kwargs) -> str:  # pragma: no cover - should not be called
+        raise AssertionError("input() should not be invoked when --yes is used")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    async def fake_submit_batch(client, trades, cfg):  # noqa: ARG001
+        return [
+            {
+                "symbol": t.symbol,
+                "status": "Filled",
+                "filled": t.quantity,
+                "avg_fill_price": 0.0,
+            }
+            for t in trades
+        ]
+
+    monkeypatch.setattr(rebalance, "submit_batch", fake_submit_batch)
+
+    args = Namespace(
+        config="config/settings.ini",
+        csv="data/portfolios.csv",
+        dry_run=False,
+        yes=True,
+        read_only=False,
+        confirm_mode="global",
+    )
+
+    asyncio.run(rebalance._run(args))
+
+    captured = capsys.readouterr().out
+    assert "Proceed? [y/N]" not in captured
+    assert captured.count("Submitting batch market orders") == 2


### PR DESCRIPTION
## Summary
- Allow CLI override of confirmation strategy via new `--confirm-mode` flag
- Support global confirmation: plan all accounts, show previews, prompt once, and submit in batch
- Ensure per-account mode respects `--yes`, and add tests for global confirmation

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d1bc213c8320ae94b4bf97ac781e