### PR TITLE
Support account selection in order batch submissions

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 async def submit_batch(
-    client: IBKRClient, trades: list[Trade], cfg: Config
+    client: IBKRClient, trades: list[Trade], cfg: Config, account_id: str
 ) -> list[dict[str, Any]]:
     """Submit a batch of market orders and wait for completion.
 
@@ -34,6 +34,8 @@ async def submit_batch(
         Sized trades to execute.
     cfg:
         Application configuration providing execution and rebalance settings.
+    account_id:
+        Account to assign to each order.
 
     Returns
     -------
@@ -75,6 +77,7 @@ async def submit_batch(
     async def _submit_one(st: Trade) -> dict[str, Any]:
         contract = Stock(st.symbol, "SMART", "USD")
         order = MarketOrder(st.action, st.quantity)
+        order.account = account_id
         algo_used = False
         algo_pref = cfg.execution.algo_preference.lower()
         if algo_pref in {"adaptive", "midprice"}:

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -227,7 +227,7 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                 logging.info("Submitting batch market orders for %s", account_id)
                 await client.connect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
                 try:
-                    results = await submit_batch(client, trades, cfg)
+                    results = await submit_batch(client, trades, cfg, account_id)
                 finally:
                     await client.disconnect(
                         cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id
@@ -368,7 +368,7 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                 client = IBKRClient()
                 await client.connect(cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id)
                 try:
-                    results = await submit_batch(client, trades, cfg)
+                    results = await submit_batch(client, trades, cfg, account_id)
                 finally:
                     await client.disconnect(
                         cfg.ibkr.host, cfg.ibkr.port, cfg.ibkr.client_id

--- a/tests/integration/test_execution_paper.py
+++ b/tests/integration/test_execution_paper.py
@@ -40,7 +40,7 @@ def test_execution_paper():
                 if not (time(9, 30) <= ny_time <= time(16, 0)):
                     pytest.skip("Outside regular trading hours")
             trade = SizedTrade("SPY", "BUY", 1.0, 0.0)
-            return await submit_batch(client, [trade], cfg)
+            return await submit_batch(client, [trade], cfg, cfg.ibkr.account_id)
         finally:
             await client.disconnect(host, port_i, client_id_i)
 

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -96,7 +96,7 @@ def test_yes_skips_prompt(
 
     monkeypatch.setattr("builtins.input", fail_input)
 
-    async def fake_submit_batch(client, trades, cfg):  # noqa: ARG001
+    async def fake_submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
         return [
             {
                 "symbol": t.symbol,
@@ -172,7 +172,7 @@ def test_yes_skips_prompt_global(
 
     monkeypatch.setattr("builtins.input", fail_input)
 
-    async def fake_submit_batch(client, trades, cfg):  # noqa: ARG001
+    async def fake_submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
         return [
             {
                 "symbol": t.symbol,

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -81,8 +81,9 @@ def test_run_submits_orders_and_prints_summary(monkeypatch, capsys):
     _setup_common(monkeypatch)
     recorded = {}
 
-    async def fake_submit_batch(client, trades, cfg):
+    async def fake_submit_batch(client, trades, cfg, account_id):
         recorded["trades"] = trades
+        recorded["account_id"] = account_id
         return [
             {"symbol": "AAA", "status": "Filled", "filled": 5.0, "avg_fill_price": 10.0}
         ]
@@ -102,7 +103,7 @@ def test_run_submits_orders_and_prints_summary(monkeypatch, capsys):
 def test_run_logs_error_on_order_failure(monkeypatch, capsys):
     _setup_common(monkeypatch)
 
-    async def fake_submit_batch(client, trades, cfg):
+    async def fake_submit_batch(client, trades, cfg, account_id):
         return [
             {
                 "symbol": "AAA",


### PR DESCRIPTION
## Summary
- allow specifying an account when submitting order batches
- set the account on each order before placing it
- propagate `account_id` through rebalance workflow and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d34e01a88320a811dec12da9877d