### PR TITLE
Add pacing_sec option for account pacing

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -73,3 +73,5 @@ log_level = INFO
 ; portfolios.csv is shared across accounts
 ids = DU111111, DU222222
 confirm_mode = per_account
+; Minimum seconds between account operations (0 disables pacing)
+pacing_sec = 0

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -85,6 +85,7 @@ class Accounts:
 
     ids: list[str]
     confirm_mode: str
+    pacing_sec: float = 0.0
 
 
 @dataclass
@@ -164,7 +165,15 @@ def load_config(path: Path) -> AppConfig:
                 "'per_account' or 'global'"
             )
             # fmt: on
-        accounts = Accounts(ids=ids, confirm_mode=confirm_mode)
+        try:
+            pacing_sec = cp.getfloat("accounts", "pacing_sec", fallback=0.0)
+        except ValueError as exc:
+            raise ConfigError("[accounts] pacing_sec must be a float") from exc
+        if pacing_sec < 0:
+            raise ConfigError("[accounts] pacing_sec must be >= 0")
+        accounts = Accounts(
+            ids=ids, confirm_mode=confirm_mode, pacing_sec=pacing_sec
+        )
         account_id = ids[0]
     else:
         if not account_id:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -137,7 +137,9 @@ baz = qux
     path = tmp_path / "settings.ini"
     path.write_text(content)
     cfg = load_config(path)
-    assert cfg.accounts == Accounts(ids=["ACC1", "ACC2"], confirm_mode="global")
+    assert cfg.accounts == Accounts(
+        ids=["ACC1", "ACC2"], confirm_mode="global", pacing_sec=0.0
+    )
     assert account_overrides == {"ACC1": {"foo": "bar"}, "ACC2": {"baz": "qux"}}
 
 
@@ -153,7 +155,9 @@ ids = ONLY
     path = tmp_path / "settings.ini"
     path.write_text(content)
     cfg = load_config(path)
-    assert cfg.accounts == Accounts(ids=["ONLY"], confirm_mode="per_account")
+    assert cfg.accounts == Accounts(
+        ids=["ONLY"], confirm_mode="per_account", pacing_sec=0.0
+    )
 
 
 def test_accounts_invalid_confirm_mode(tmp_path: Path) -> None:
@@ -185,7 +189,7 @@ ids = ACC1, ACC2, ACC1 , ACC3
     path.write_text(content)
     cfg = load_config(path)
     assert cfg.accounts == Accounts(
-        ids=["ACC1", "ACC2", "ACC3"], confirm_mode="per_account"
+        ids=["ACC1", "ACC2", "ACC3"], confirm_mode="per_account", pacing_sec=0.0
     )
     assert cfg.ibkr.account_id == "ACC1"
     # Existing fields remain unchanged
@@ -307,7 +311,7 @@ ids =   ACC1,ACC2  ,  ACC3
     path.write_text(content)
     cfg = load_config(path)
     assert cfg.accounts == Accounts(
-        ids=["ACC1", "ACC2", "ACC3"], confirm_mode="per_account"
+        ids=["ACC1", "ACC2", "ACC3"], confirm_mode="per_account", pacing_sec=0.0
     )
     assert cfg.ibkr.account_id == "ACC1"
     # Existing fields unaffected
@@ -326,7 +330,9 @@ ids = ONLY
     path = tmp_path / "settings.ini"
     path.write_text(content)
     cfg = load_config(path)
-    assert cfg.accounts == Accounts(ids=["ONLY"], confirm_mode="per_account")
+    assert cfg.accounts == Accounts(
+        ids=["ONLY"], confirm_mode="per_account", pacing_sec=0.0
+    )
     assert cfg.ibkr.account_id == "ONLY"
     assert cfg.rebalance.min_order_usd == 500
 
@@ -344,6 +350,42 @@ unknown = something
     path = tmp_path / "settings.ini"
     path.write_text(content)
     cfg = load_config(path)
-    assert cfg.accounts == Accounts(ids=["ACC1", "ACC2"], confirm_mode="per_account")
+    assert cfg.accounts == Accounts(
+        ids=["ACC1", "ACC2"], confirm_mode="per_account", pacing_sec=0.0
+    )
     assert cfg.ibkr.account_id == "ACC1"
     assert cfg.io.log_level == "INFO"
+
+
+def test_accounts_pacing_sec_valid(tmp_path: Path) -> None:
+    content = (
+        VALID_CONFIG
+        + """\
+
+[accounts]
+ids = ACC1, ACC2
+pacing_sec = 2.5
+"""
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    cfg = load_config(path)
+    assert cfg.accounts == Accounts(
+        ids=["ACC1", "ACC2"], confirm_mode="per_account", pacing_sec=2.5
+    )
+
+
+def test_accounts_pacing_sec_negative(tmp_path: Path) -> None:
+    content = (
+        VALID_CONFIG
+        + """\
+
+[accounts]
+ids = ACC1
+pacing_sec = -1
+"""
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    with pytest.raises(ConfigError):
+        load_config(path)


### PR DESCRIPTION
## Summary
- support per-account pacing via new `pacing_sec` field
- parse optional `pacing_sec` with default 0 and validation
- document and test the pacing option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d924ebcc83209397041a2d127625