### PR TITLE
Use async IBKRClient context per account

### DIFF
--- a/src/broker/ibkr_client.py
+++ b/src/broker/ibkr_client.py
@@ -48,6 +48,11 @@ class IBKRClient:
 
         if None in (self._host, self._port, self._client_id):
             raise IBKRError("host, port and client_id required for context manager")
+        assert (
+            self._host is not None
+            and self._port is not None
+            and self._client_id is not None
+        )
         await self.connect(self._host, self._port, self._client_id)
         return self
 
@@ -56,6 +61,11 @@ class IBKRClient:
 
         if None not in (self._host, self._port, self._client_id):
             try:
+                assert (
+                    self._host is not None
+                    and self._port is not None
+                    and self._client_id is not None
+                )
                 await self.disconnect(self._host, self._port, self._client_id)
             except Exception:  # pragma: no cover - disconnect errors
                 log.exception("Error while disconnecting from IBKR")


### PR DESCRIPTION
## Summary
- manage IBKR connections with async context managers per account, falling back to manual connection when needed
- insert pacing sleeps between accounts to respect API limits
- enforce non-None parameters in IBKRClient context manager

## Testing
- `pre-commit run --files src/rebalance.py src/broker/ibkr_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9df7377808320a510818ee505a1ee