### PR TITLE
Document default 'none' algorithm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ timestamp_run,account_id,planned_orders,submitted,filled,rejected,buy_usd,sell_u
 
 ### Order execution module
 `src/broker/execution.py` submits the confirmed trades and supports IBKR's
-Adaptive or Midprice algos via `execution.algo_preference`. Submitted orders
+`none`, Adaptive, or Midprice algos via `execution.algo_preference`. Submitted orders
 are tagged with their account code so Interactive Brokers books them correctly.
 If the selected algo is rejected and `fallback_plain_market` is true, it retries
 with a plain market order. Trading hours are controlled by

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -53,8 +53,8 @@ fallback_to_snapshot = true
 [execution]
 ; Order type (market only)
 order_type = market
-; Preferred algo: adaptive | midprice. For execution certainty (e.g., rebalancing portfolios) use Adaptive. Use Midprice when spreads are wide, liquidity is decent, and you want cost savings, but risk never been filled.
-algo_preference = adaptive
+; Preferred algo: none | adaptive | midprice. Use 'none' for plain market orders. For execution certainty (e.g., rebalancing portfolios) use Adaptive. Use Midprice when spreads are wide, liquidity is decent, and you want cost savings but risk not being filled.
+algo_preference = none
 ; true falls back to plain market if algo fails
 fallback_plain_market = true
 ; true submits orders in batches

--- a/dev-plan/srs.md
+++ b/dev-plan/srs.md
@@ -88,7 +88,7 @@ fallback_to_snapshot = true
 
 [execution]
 order_type = market               ; market only
-algo_preference = adaptive        ; adaptive | midprice
+algo_preference = none            ; none | adaptive | midprice
 fallback_plain_market = true      ; fallback if algo unsupported
 batch_orders = true               ; send in batches
 
@@ -125,7 +125,7 @@ log_level = INFO
    - Show a **batch summary** (gross to buy/sell, est. exposure, leverage) before prompting.
    - Prompt **Y/N** at CLI.
 10. **Execute** (on `Y`):
-    - Submit **batch market orders** with preferred **algo** (adaptive or midprice) when supported by IBKR; otherwise **fallback to plain market**.
+    - Submit **batch market orders** with preferred **algo** (`none`, `adaptive`, or `midprice`) when supported by IBKR; `none` or unsupported algos **fallback to plain market**.
     - Honor `trading_hours` (`eth` sets outsideRth for extended sessions).
     - Monitor orders until Filled/Cancelled.
 11. **Report & Log**: write **timestamped CSV** for the run; include per-order fills; append human-readable log lines.  
@@ -155,8 +155,8 @@ Proceed? [y/N]:
 
 - **Sizing/preview valuation** uses `price_source` (last by default) with optional snapshot fallback.  
 - **Order type:** **Market** only.  
-- **Algo preference:** `adaptive` (or `midprice`), if available for the symbol/venue.  
-- **Fallback:** If “market-with-algo” is rejected or unsupported, **fallback to plain market**.  
+- **Algo preference:** `none`, `adaptive`, or `midprice` if available for the symbol/venue.
+- **Fallback:** If `algo_preference` is `none` or the selected algo is rejected/unsupported, **fallback to plain market**.
 - **Trading hours:** `trading_hours=rth` submits only during regular trading hours. `eth` enables extended-hours execution.
 
 ---
@@ -215,7 +215,7 @@ Proceed? [y/N]:
 - Compute projected **gross exposure** and **leverage**; if projected leverage > `max_leverage`, scale back lower-priority trades until compliant.
 
 ### 8.5 Execution
-- Build orders as **market** with **algo_preference** where supported; otherwise plain market.  
+- Build orders as **market** with `algo_preference` (`none`, `adaptive`, or `midprice`) where supported; `none` or unsupported algos submit plain market orders.
 - Submit in a **batch**; track order IDs; poll for status until terminal.
 
 ---

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -2,7 +2,7 @@
 
 **Audience:** You (Julian) and future contributors  
 **Source docs:** SRS (Detailed v1), plan.md (Project Plan)  
-**Goal:** Ship an MVP that **trades live on IBKR paper** with preview/confirm, market orders (adaptive/midprice preferred, fallback plain market), CSV reporting, and CI discipline.
+**Goal:** Ship an MVP that **trades live on IBKR paper** with preview/confirm, market orders (`none`, `adaptive`, or `midprice`; fallback plain market), CSV reporting, and CI discipline.
 
 ---
 
@@ -153,7 +153,7 @@ fallback_to_snapshot = true
 
 [execution]
 order_type = market
-algo_preference = adaptive
+algo_preference = none
 fallback_plain_market = true
 batch_orders = true
 
@@ -374,7 +374,7 @@ Proceed? [y/N]:
 *Runs after the user confirms the preview in Phase C4.*
 
 **Implement** `src/broker/execution.py`
-- Build **market orders**; set algo preference (`adaptive`/`midprice`) where supported; else **fallback to plain market**.
+- Build **market orders**; set `algo_preference` (`none`/`adaptive`/`midprice`) where supported; `none` or unsupported algos **fallback to plain market**.
 - Batch submit; track order IDs; poll until Filled/Rejected/Cancelled.
 - Set `outsideRth=True` when `trading_hours` is `eth`; rely on IBKR for `rth`.
 

--- a/math-logic.md
+++ b/math-logic.md
@@ -269,13 +269,13 @@ This project is like a helpful robot that keeps an investment portfolio tidy. It
 
 ### `execution.algo_preference`
 **What it is**
-: Preferred IBKR algo, like `adaptive` or `midprice`.
+: Preferred IBKR algo: `none` for plain market orders, or `adaptive`/`midprice` for IBKR's algos.
 
 **Why it matters**
 : Algos can try to get better prices or faster fills.
 
 **Example with numbers**
-: With `algo_preference = adaptive`, IBKR may slice a 100-share order into smaller pieces automatically.
+: With `algo_preference = adaptive`, IBKR may slice a 100-share order into smaller pieces automatically; with `none`, the order is submitted as a plain market order.
 
 ### `execution.fallback_plain_market`
 **What it is**


### PR DESCRIPTION
## Summary
- Explain that `execution.algo_preference` accepts `none`, `adaptive`, or `midprice`
- Default `execution.algo_preference` to `none` for plain market orders
- Mention the `none` option across README, SRS, workflow guide, and math-logic docs

## Testing
- `pre-commit run --files config/settings.ini README.md dev-plan/srs.md dev-plan/workflow.md math-logic.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ecfec69483209a6078f9e58fe8d6