### PR TITLE
Filter IBKR snapshot to target account

### DIFF
--- a/src/broker/ibkr_client.py
+++ b/src/broker/ibkr_client.py
@@ -105,6 +105,7 @@ class IBKRClient:
         try:
             log.info("Starting account snapshot for %s", account_id)
             positions: List[Position] = await self._ib.reqPositionsAsync()
+            positions = [p for p in positions if p.account == account_id]
             usd_positions = [
                 {
                     "account": p.account,
@@ -116,9 +117,12 @@ class IBKRClient:
                 if p.contract.currency == "USD"
             ]
 
-            # Ensure account summary data is fetched
-            await self._ib.reqAccountSummaryAsync()
+            # Ensure account summary data is fetched for the target account
+            await self._ib.reqAccountSummaryAsync(account_id)
             summary = await self._ib.accountSummaryAsync(account_id)
+            summary = [
+                s for s in summary if getattr(s, "account", account_id) == account_id
+            ]
 
             cash_usd = 0.0
             net_liq_usd = 0.0

--- a/tests/unit/test_ibkr_client.py
+++ b/tests/unit/test_ibkr_client.py
@@ -34,9 +34,15 @@ class FakeIBSnapshot:
                 position=5,
                 avgCost=150.0,
             ),
+            SimpleNamespace(
+                account="OTHER",
+                contract=SimpleNamespace(symbol="MSFT", currency="USD"),
+                position=20,
+                avgCost=200.0,
+            ),
         ]
 
-    async def reqAccountSummaryAsync(self):
+    async def reqAccountSummaryAsync(self, account_id):
         return None
 
     async def accountSummaryAsync(self, account_id):
@@ -64,6 +70,8 @@ def test_snapshot_filters_cad_cash(monkeypatch):
         "cash": 1000.0,
         "net_liq": 1500.0,
     }
+    symbols = {p["symbol"] for p in result["positions"]}
+    assert "MSFT" not in symbols
 
 
 class FailingIB:


### PR DESCRIPTION
## Summary
- filter positions and account summary to the requested account in IBKR snapshot
- exercise multi-account scenarios in snapshot unit test

## Testing
- `pytest -q tests/unit/test_ibkr_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5eafa2c8320a3fc1944ccc48a93