### PR TITLE
Clarify shared client_id usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,10 @@ timestamp_run,account_id,planned_orders,submitted,filled,rejected,buy_usd,sell_u
 
 ### Operational notes & safeguards
 
-* **Client isolation** – Each account operates under its own IBKR client ID and
-  orders are tagged with the relevant account code so activity for one account
-  cannot leak into another.
+* **Client isolation** – Orders are tagged with each account code so activity
+  remains separated. All accounts share the `[ibkr]` `client_id` in
+  `config/settings.ini`; per-account client IDs are not currently supported, so
+  use separate runs with different configs if distinct IDs are required.
 * **Pacing and backoff** – Requests are throttled to respect IBKR pacing limits.
   The rebalancer backs off and retries when the API signals rate‑limit
   violations.

--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -152,16 +152,13 @@ async def submit_batch(
         avg_price_first = float(getattr(ib_trade.orderStatus, "avgFillPrice", 0.0))
         exec_objs = [ib_trade]
         if fallback_trade is not None:
-            filled_second = float(
-                getattr(fallback_trade.orderStatus, "filled", 0.0)
-            )
+            filled_second = float(getattr(fallback_trade.orderStatus, "filled", 0.0))
             avg_price_second = float(
                 getattr(fallback_trade.orderStatus, "avgFillPrice", 0.0)
             )
             filled = filled_first + filled_second
             avg_price = (
-                (filled_first * avg_price_first)
-                + (filled_second * avg_price_second)
+                (filled_first * avg_price_first) + (filled_second * avg_price_second)
             ) / filled
             exec_objs.append(fallback_trade)
         else:


### PR DESCRIPTION
## Summary
- Document that all accounts share the `[ibkr]` `client_id` and per-account client IDs are not supported.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6a4d0bc8320bb7ca420ebd49932