### PR TITLE
Drop legacy ibkr account_id config

### DIFF
--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -294,12 +294,13 @@ _Status: Completed with batch-summary preview._
 - Activate env; `pip install -r requirements.txt -r requirements-dev.txt`
 
 2) **IBKR TWS/Gateway**
-- Install and run TWS or IB Gateway (paper)  
-- Enable API, set host/port (default 127.0.0.1:4002), and your `account_id`
+- Install and run TWS or IB Gateway (paper)
+- Enable API, set host/port (default 127.0.0.1:4002), and configure your
+  account IDs under `[accounts]`
 - Ensure connectivity: sample snapshot command returns positions
 
 3) **Pre-commit & CI**
-- `pre-commit install`  
+- `pre-commit install`
 - Push to GitHub; confirm Actions CI runs and passes
 
 ---

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -129,6 +129,10 @@ def load_config(path: Path) -> AppConfig:
         read_only = cp.getboolean("ibkr", "read_only")
     except (NoSectionError, NoOptionError, ValueError) as exc:
         raise ConfigError(f"[ibkr] {exc}") from exc
+    if cp.has_option("ibkr", "account_id"):
+        raise ConfigError(
+            "[ibkr] account_id is no longer supported; use [accounts] ids"
+        )
     if port <= 0:
         raise ConfigError("[ibkr] port must be positive")
     if client_id < 0:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -135,6 +135,16 @@ def test_accounts_pacing_sec_negative(tmp_path: Path) -> None:
         load_config(path)
 
 
+def test_ibkr_account_id_rejected(tmp_path: Path) -> None:
+    content = VALID_CONFIG.replace(
+        "read_only = true", "read_only = true\naccount_id = DU111111"
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
 def test_non_numeric_port(tmp_path: Path) -> None:
     content = VALID_CONFIG.replace("port = 4002", "port = not_a_number")
     path = tmp_path / "settings.ini"


### PR DESCRIPTION
## Summary
- reject `[ibkr] account_id` in config loader
- document only `[accounts]` ids, removing legacy single-account mention
- add regression test for legacy `account_id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1637a7a08320b4aad4e869760f0a