### PR TITLE
docs: explain account override blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ python src/rebalance.py --dry-run --confirm-mode global --config config/settings
 Orders sent to Interactive Brokers are tagged with the respective account code
 so each account's trades remain isolated.
 
+### Account-specific overrides (experimental)
+
+`settings.ini` may contain optional `[account:<ID>]` blocks to override
+settings for a single account. The configuration loader parses these sections,
+but the application currently ignores them, so they behave like placeholders for
+future features.
+
+```ini
+[account:DU111111]
+allow_fractional = true       ; overrides [rebalance] allow_fractional
+```
+
+Any keys omitted in the block fall back to the global values defined elsewhere
+in the file (for example, `[rebalance]` or `[accounts]`).
+
 ## Usage
 
 ### Validate configuration

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -18,6 +18,11 @@ confirm_mode = per_account
 ; Minimum seconds between account operations (0 disables pacing)
 pacing_sec = 5
 
+; Example per-account overrides (parsed but not enforced)
+; [account:DU111111]
+; allow_fractional = true       ; override [rebalance] allow_fractional
+; Unspecified keys fall back to global values
+
 [models]
 ; Weight for SMURF model (0-1, weights must sum to 1.0)
 smurf = 0.50


### PR DESCRIPTION
## Summary
- document experimental `[account:<ID>]` blocks for per-account config overrides
- illustrate override usage in sample settings file

## Testing
- `pre-commit run --files README.md config/settings.ini`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1dba40dc8320bb17062e4cd5c4ba