### PR TITLE
Support per-account override configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,26 @@ python src/rebalance.py --dry-run --confirm-mode global --config config/settings
 Orders sent to Interactive Brokers are tagged with the respective account code
 so each account's trades remain isolated.
 
-### Account-specific overrides (experimental)
+### Account-specific overrides
 
 `settings.ini` may contain optional `[account:<ID>]` blocks to override
-settings for a single account. The configuration loader parses these sections,
-but the application currently ignores them, so they behave like placeholders for
-future features.
+settings for a single account.  Values inside these blocks take precedence over
+the global `[rebalance]` settings for that account only; other accounts continue
+to use the global defaults.  Keys that are not specified fall back to the
+global values.
 
 ```ini
+[rebalance]
+allow_fractional = false
+min_order_usd = 50
+
 [account:DU111111]
-allow_fractional = true       ; overrides [rebalance] allow_fractional
+allow_fractional = true       ; only DU111111 allows fractional shares
+min_order_usd = 10            ; lower minimum order just for DU111111
 ```
 
-Any keys omitted in the block fall back to the global values defined elsewhere
-in the file (for example, `[rebalance]` or `[accounts]`).
+In this example, account `DU111111` can submit fractional orders as small as
+$10 while all other accounts require whole-share orders of at least $50.
 
 ## Usage
 

--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -11,6 +11,7 @@ from ib_async.order import MarketOrder, TagValue
 
 from src.core.sizing import SizedTrade as Trade
 from src.io import AppConfig as Config
+from src.io import merge_account_overrides
 
 from .errors import IBKRError
 from .ibkr_client import IBKRClient
@@ -41,6 +42,7 @@ async def submit_batch(
         Structured execution results for each trade.
     """
 
+    cfg = merge_account_overrides(cfg, account_id)
     log.info("Starting batch execution of %d trades", len(trades))
     ib = cast(Any, client._ib)
 

--- a/src/core/planner.py
+++ b/src/core/planner.py
@@ -12,7 +12,7 @@ from src.core.errors import PlanningError
 from src.core.preview import render as render_preview
 from src.core.pricing import PricingError, get_price
 from src.core.sizing import SizedTrade
-from src.io import AppConfig
+from src.io import AppConfig, merge_account_overrides
 from src.io.reporting import write_pre_trade_report
 
 
@@ -64,6 +64,7 @@ async def plan_account(
     write_pre_trade_report=write_pre_trade_report,
 ) -> Plan:
     """Plan trades for a single account."""
+    cfg = merge_account_overrides(cfg, account_id)
 
     print(
         f"[blue]Connecting to IBKR at {cfg.ibkr.host}:{cfg.ibkr.port} (client id {cfg.ibkr.client_id}) for account {account_id}[/blue]"

--- a/src/core/sizing.py
+++ b/src/core/sizing.py
@@ -20,6 +20,8 @@ import math
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from src.io import merge_account_overrides
+
 from .drift import Drift
 
 
@@ -83,6 +85,8 @@ def size_orders(
     """
 
     logging.debug("Sizing orders for account %s", account_id)
+
+    cfg = merge_account_overrides(cfg, account_id)
 
     (
         min_order_usd,

--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -8,6 +8,7 @@ types without reaching into the underlying modules.
 from .config_loader import (
     IBKR,
     IO,
+    AccountOverride,
     Accounts,
     AppConfig,
     ConfigError,
@@ -16,8 +17,8 @@ from .config_loader import (
     Models,
     Pricing,
     Rebalance,
-    account_overrides,
     load_config,
+    merge_account_overrides,
 )
 from .portfolio_csv import PortfolioCSVError, load_portfolios, validate_symbols
 from .reporting import (
@@ -35,11 +36,12 @@ __all__ = [
     "Execution",
     "IBKR",
     "IO",
-    "account_overrides",
+    "AccountOverride",
     "Models",
     "Pricing",
     "Rebalance",
     "load_config",
+    "merge_account_overrides",
     "PortfolioCSVError",
     "load_portfolios",
     "validate_symbols",

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -20,7 +20,13 @@ from src.core.errors import PlanningError
 from src.core.planner import Plan, _fetch_price, plan_account
 from src.core.preview import render as render_preview
 from src.core.sizing import size_orders
-from src.io import AppConfig, ConfigError, ConfirmMode, load_config
+from src.io import (
+    AppConfig,
+    ConfigError,
+    ConfirmMode,
+    load_config,
+    merge_account_overrides,
+)
 from src.io.portfolio_csv import PortfolioCSVError, load_portfolios
 from src.io.reporting import (
     append_run_summary,
@@ -59,10 +65,11 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
     for account_id in accounts.ids:
         plan: Plan | None = None
         try:
+            cfg_acct = merge_account_overrides(cfg, account_id)
             plan = await plan_account(
                 account_id,
                 portfolios,
-                cfg,
+                cfg_acct,
                 ts_dt,
                 client_factory=IBKRClient,
                 compute_drift=compute_drift,
@@ -76,7 +83,7 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                 await confirm_per_account(
                     plan,
                     args,
-                    cfg,
+                    cfg_acct,
                     ts_dt,
                     client_factory=IBKRClient,
                     submit_batch=submit_batch,

--- a/tests/unit/test_account_overrides.py
+++ b/tests/unit/test_account_overrides.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core.drift import Drift  # noqa: E402
+from src.core.sizing import size_orders  # noqa: E402
+from src.io.config_loader import AccountOverride  # noqa: E402
+
+
+def _cfg():
+    reb = SimpleNamespace(
+        min_order_usd=50,
+        allow_fractional=False,
+        cash_buffer_type="pct",
+        cash_buffer_pct=0.0,
+        cash_buffer_abs=0.0,
+        max_leverage=2.0,
+    )
+    overrides = {"ACC1": AccountOverride(allow_fractional=True, min_order_usd=10)}
+    return SimpleNamespace(rebalance=reb, account_overrides=overrides)
+
+
+def _drift(symbol: str, usd: float, net_liq: float) -> Drift:
+    pct = usd / net_liq * 100.0
+    action = "BUY" if usd < 0 else "SELL" if usd > 0 else "HOLD"
+    current = 0.0
+    target = -pct
+    return Drift(symbol, target, current, pct, usd, action)
+
+
+def test_overrides_affect_only_target_account():
+    net_liq = 1000.0
+    drifts = [_drift("AAA", -30.0, net_liq), _drift("BBB", -80.0, net_liq)]
+    prices = {"AAA": 7.0, "BBB": 30.0}
+    cfg = _cfg()
+
+    trades1, _, _ = size_orders(
+        "ACC1", drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
+    )
+    trades2, _, _ = size_orders(
+        "ACC2", drifts, prices, cash=200.0, net_liq=net_liq, cfg=cfg
+    )
+
+    trades1_sorted = sorted(trades1, key=lambda t: t.symbol)
+    assert len(trades1_sorted) == 2
+    t_aaa, t_bbb = trades1_sorted
+    assert t_aaa.symbol == "AAA"
+    assert t_aaa.action == "BUY"
+    assert t_aaa.notional == pytest.approx(30.0)
+    assert t_aaa.quantity == pytest.approx(30.0 / 7.0)
+    assert t_bbb.symbol == "BBB"
+    assert t_bbb.action == "BUY"
+    assert t_bbb.notional == pytest.approx(80.0)
+    assert t_bbb.quantity == pytest.approx(80.0 / 30.0)
+
+    assert len(trades2) == 1
+    t2 = trades2[0]
+    assert t2.symbol == "BBB"
+    assert t2.action == "BUY"
+    assert t2.notional == pytest.approx(60.0)
+    assert t2.quantity == pytest.approx(2.0)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -16,7 +16,6 @@ from src.io.config_loader import (  # noqa: E402
     Models,
     Pricing,
     Rebalance,
-    account_overrides,
     load_config,
 )
 
@@ -163,8 +162,9 @@ def test_account_section_unknown_keys(tmp_path: Path) -> None:
     path.write_text(content)
     cfg = load_config(path)
     assert cfg.accounts.ids == ["ACC1", "ACC2"]
-    assert account_overrides["ACC1"]["foo"] == "bar"
-    assert account_overrides["ACC1"]["unknown"] == "baz"
+    overrides = cfg.account_overrides["ACC1"]
+    assert overrides.extra["foo"] == "bar"
+    assert overrides.extra["unknown"] == "baz"
 
 
 def test_ibkr_account_id_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- structure account-specific override blocks as dataclasses and expose them via AppConfig
- merge account overrides with global settings before planning, sizing, and execution
- document override precedence and add tests for targeted override behavior

## Testing
- `pre-commit run --files src/io/config_loader.py src/io/__init__.py src/rebalance.py src/core/planner.py src/core/sizing.py src/broker/execution.py tests/unit/test_config_loader.py tests/unit/test_account_overrides.py README.md` 
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba28ee4c74832099ff0b14ac4006c6