### PR TITLE
feat: add parallel account execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ section:
 ids = DU111111, DU222222
 confirm_mode = per_account        ; per_account | global
 pacing_sec = 1                    ; seconds to pause between accounts
+parallel = false                  ; true processes accounts concurrently
 ```
 
 The same `portfolios.csv` applies to all listed accounts. `confirm_mode`
@@ -53,6 +54,8 @@ runtime via `--confirm-mode`:
 * `global` shows all account previews first, then prompts once for the batch.
 
 `pacing_sec` throttles between accounts by pausing for the specified number of seconds.
+Set `parallel = true` to plan and execute accounts concurrently. The same can
+be enabled at runtime via `--parallel-accounts`.
 
 Example forcing a global prompt:
 
@@ -133,10 +136,11 @@ Displays the batch summary and exits without placing orders.
 
 ### Dry run across multiple accounts
 When `[accounts]` lists more than one ID, the rebalancer previews each
-account in sequence. Run the same command to simulate the batch:
+account in sequence. Run the same command to simulate the batch, or add
+`--parallel-accounts` to process them concurrently:
 
 ```bash
-python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --parallel-accounts --config config/settings.ini --csv data/portfolios.csv
 ```
 
 Each account prints its own table. Example output:

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -17,6 +17,8 @@ ids = DU111111, DU222222
 confirm_mode = per_account
 ; Minimum seconds between account operations (0 disables pacing)
 pacing_sec = 5
+; Process accounts concurrently when true
+parallel = false
 
 ; Example per-account overrides (parsed but not enforced)
 ; [account:DU111111]

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -108,6 +108,7 @@ class Accounts:
     ids: list[str]
     confirm_mode: ConfirmMode
     pacing_sec: float = 0.0
+    parallel: bool = False
 
 
 @dataclass
@@ -267,7 +268,16 @@ def load_config(path: Path) -> AppConfig:
         raise ConfigError("[accounts] pacing_sec must be a float") from exc
     if pacing_sec < 0:
         raise ConfigError("[accounts] pacing_sec must be >= 0")
-    accounts = Accounts(ids=ids, confirm_mode=confirm_mode, pacing_sec=pacing_sec)
+    try:
+        parallel = cp.getboolean("accounts", "parallel", fallback=False)
+    except ValueError as exc:
+        raise ConfigError("[accounts] parallel must be a boolean") from exc
+    accounts = Accounts(
+        ids=ids,
+        confirm_mode=confirm_mode,
+        pacing_sec=pacing_sec,
+        parallel=parallel,
+    )
 
     ibkr = IBKR(
         host=host,

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -134,12 +134,15 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
         tasks = []
         pacing = getattr(accounts, "pacing_sec", 0.0)
         for idx, account_id in enumerate(accounts.ids):
+
             async def start_after_delay(aid: str, delay: float) -> Plan | None:
                 if delay:
                     await asyncio.sleep(delay)
                 return await handle_account(aid)
 
-            tasks.append(asyncio.create_task(start_after_delay(account_id, idx * pacing)))
+            tasks.append(
+                asyncio.create_task(start_after_delay(account_id, idx * pacing))
+            )
         results = await asyncio.gather(*tasks)
         plans.extend([p for p in results if p is not None])
     else:

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -1,0 +1,127 @@
+import asyncio
+import csv
+import time
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+import src.rebalance as rebalance
+
+pytestmark = pytest.mark.integration
+
+
+class DummyClient:
+    instances: list["DummyClient"] = []
+
+    def __init__(self) -> None:
+        DummyClient.instances.append(self)
+
+    async def connect(self, host: str, port: int, client_id: int) -> None:  # noqa: ARG002
+        pass
+
+    async def disconnect(self, host: str, port: int, client_id: int) -> None:  # noqa: ARG002
+        pass
+
+
+async def fake_load_portfolios(csv_path, host, port, client_id):  # noqa: ARG001
+    return {}
+
+
+async def stub_plan_account(account_id, portfolios, cfg, ts_dt, **kwargs):  # noqa: ARG001, D401
+    client_factory = kwargs.get("client_factory", rebalance.IBKRClient)
+    client_factory()
+    await asyncio.sleep(0.1)
+    return {
+        "account_id": account_id,
+        "table": "",
+        "trades": [],
+        "drifts": [],
+        "prices": {},
+        "current": {},
+        "targets": {},
+        "net_liq": 0.0,
+        "pre_gross_exposure": 0.0,
+        "pre_leverage": 0.0,
+        "post_leverage": 0.0,
+        "planned_orders": 0,
+        "buy_usd": 0.0,
+        "sell_usd": 0.0,
+    }
+
+
+async def stub_confirm_per_account(
+    plan,
+    args,
+    cfg,
+    ts_dt,
+    *,
+    client_factory,
+    submit_batch,  # noqa: ARG002
+    append_run_summary,
+    write_post_trade_report,  # noqa: ARG002
+    compute_drift,  # noqa: ARG002
+    prioritize_by_drift,  # noqa: ARG002
+    size_orders,  # noqa: ARG002
+):
+    client_factory()
+    await asyncio.sleep(0.1)
+    append_run_summary(
+        Path(cfg.io.report_dir),
+        ts_dt,
+        {
+            "timestamp_run": ts_dt.isoformat(),
+            "account_id": plan["account_id"],
+            "planned_orders": 0,
+            "submitted": 0,
+            "filled": 0,
+            "rejected": 0,
+            "buy_usd": 0.0,
+            "sell_usd": 0.0,
+            "pre_leverage": 0.0,
+            "post_leverage": 0.0,
+            "status": "ok",
+            "error": "",
+        },
+    )
+
+
+def test_parallel_accounts(monkeypatch, tmp_path):
+    monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
+    monkeypatch.setattr(rebalance, "plan_account", stub_plan_account)
+    monkeypatch.setattr(rebalance, "confirm_per_account", stub_confirm_per_account)
+    monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
+
+    original_load_config = rebalance.load_config
+
+    def fake_load_config(path):
+        cfg = original_load_config(path)
+        cfg.accounts.ids = ["DU111111", "DU222222"]
+        cfg.accounts.parallel = True
+        cfg.accounts.pacing_sec = 0.0
+        cfg.io.report_dir = str(tmp_path / "reports")
+        return cfg
+
+    monkeypatch.setattr(rebalance, "load_config", fake_load_config)
+
+    args = SimpleNamespace(
+        config="config/settings.ini",
+        csv="data/portfolios.csv",
+        dry_run=True,
+        yes=False,
+        read_only=False,
+        parallel_accounts=False,
+    )
+
+    start = time.perf_counter()
+    asyncio.run(rebalance._run(args))
+    duration = time.perf_counter() - start
+    assert duration < 0.3
+
+    assert len({id(c) for c in DummyClient.instances}) == len(DummyClient.instances)
+
+    report_files = list((tmp_path / "reports").glob("run_summary_*.csv"))
+    assert len(report_files) == 1
+    with report_files[0].open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert [row["account_id"] for row in rows] == ["DU111111", "DU222222"]

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -1,8 +1,8 @@
 import asyncio
 import csv
 import time
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,10 +17,14 @@ class DummyClient:
     def __init__(self) -> None:
         DummyClient.instances.append(self)
 
-    async def connect(self, host: str, port: int, client_id: int) -> None:  # noqa: ARG002
+    async def connect(
+        self, host: str, port: int, client_id: int
+    ) -> None:  # noqa: ARG002
         pass
 
-    async def disconnect(self, host: str, port: int, client_id: int) -> None:  # noqa: ARG002
+    async def disconnect(
+        self, host: str, port: int, client_id: int
+    ) -> None:  # noqa: ARG002
         pass
 
 
@@ -28,7 +32,9 @@ async def fake_load_portfolios(csv_path, host, port, client_id):  # noqa: ARG001
     return {}
 
 
-async def stub_plan_account(account_id, portfolios, cfg, ts_dt, **kwargs):  # noqa: ARG001, D401
+async def stub_plan_account(
+    account_id, portfolios, cfg, ts_dt, **kwargs
+):  # noqa: ARG001, D401
     client_factory = kwargs.get("client_factory", rebalance.IBKRClient)
     client_factory()
     await asyncio.sleep(0.1)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -103,7 +103,10 @@ def test_load_valid_config(config_file: Path) -> None:
         ),
         io=IO(report_dir="reports", log_level="INFO"),
         accounts=Accounts(
-            ids=["ACC1", "ACC2"], confirm_mode=ConfirmMode.PER_ACCOUNT, pacing_sec=0.0
+            ids=["ACC1", "ACC2"],
+            confirm_mode=ConfirmMode.PER_ACCOUNT,
+            pacing_sec=0.0,
+            parallel=False,
         ),
     )
     assert cfg == expected
@@ -146,6 +149,17 @@ def test_accounts_ids_trim_and_deduplicate(tmp_path: Path) -> None:
     path.write_text(content)
     cfg = load_config(path)
     assert cfg.accounts.ids == ["ACC1", "ACC2"]
+
+
+def test_accounts_parallel_flag(tmp_path: Path) -> None:
+    content = VALID_CONFIG.replace(
+        "ids = ACC1, ACC2",
+        "ids = ACC1, ACC2\nparallel = true",
+    )
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    cfg = load_config(path)
+    assert cfg.accounts.parallel is True
 
 
 def test_single_account_id(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `accounts.parallel` config and `--parallel-accounts` CLI flag
- run account workflows concurrently with pacing and ordered reporting
- document parallel execution and add integration test for parallel flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba2ba4dc988320b27f831318db19bd