### PR TITLE
Document per-account override enforcement

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -20,7 +20,7 @@ pacing_sec = 5
 ; Process accounts concurrently when true
 parallel = false
 
-; Example per-account overrides (parsed but not enforced)
+; Example per-account overrides (parsed and enforced)
 ; [account:DU111111]
 ; allow_fractional = true       ; override [rebalance] allow_fractional
 ;cash_buffer_type = abs         ; override [rebalance] cash_buffer_type

--- a/dev-plan/checklist_addon.md
+++ b/dev-plan/checklist_addon.md
@@ -7,7 +7,7 @@ Use this checklist to track progress through each phase.
 ## Phase 1 — Config plumbing & compatibility
 - [ ] Add `[accounts]` section to `settings.ini`
 - [ ] Validate multiple IDs and confirm precedence
-- [ ] Implement account overrides (future-proof parsing)
+- [ ] Implement and enforce account overrides
 - [ ] Unit tests for parsing and compatibility
 - [ ] Update README with config examples
 

--- a/dev-plan/plan_addon.md
+++ b/dev-plan/plan_addon.md
@@ -6,8 +6,8 @@ This document outlines a 4-phase plan to implement the SRS add-on for supporting
 
 ## Phase 1 — Config plumbing & compatibility
 **Scope**
-- Add `[accounts]` section to `settings.ini` with `ids=` list and `confirm_mode=` (`per_account` default). 
-- Parse (but do not yet enforce) future-proof per-account overrides; fall back to global values.
+- Add `[accounts]` section to `settings.ini` with `ids=` list and `confirm_mode=` (`per_account` default).
+- Parse and enforce per-account overrides; fall back to global values.
 
 **Code tasks**
 - INI parser updates + validation (non-empty IDs, dedupe, preserve order).

--- a/dev-plan/srs_addon.md
+++ b/dev-plan/srs_addon.md
@@ -28,7 +28,7 @@ ids = DU111111, DU222222, DU333333   ; comma‑separated account codes
 confirm_mode = per_account            ; per_account | global
 ```
 
-### 2.2 Account‑specific overrides (future‑proof)
+### 2.2 Account‑specific overrides
 ```ini
 [account:DU111111]
 allow_fractional = false


### PR DESCRIPTION
## Summary
- Clarify Phase 1 to parse and enforce per-account overrides
- Update checklist and SRS add-on docs to reference enforcement
- Note in sample config that per-account overrides are enforced

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba2d4c9dac8320b00bd3804b38d29a