### PR TITLE
feat: support per-account portfolio overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ min_order_usd = 10            ; lower minimum order just for DU111111
 In this example, account `DU111111` can submit fractional orders as small as
 $10 while all other accounts require whole-share orders of at least $50.
 
+### Per-account portfolio files
+
+By default all accounts share the CSV passed via `--csv`.  Specify a separate
+portfolio for an account using `[portfolio:<ID>]` blocks:
+
+```ini
+[portfolio:DU111111]
+path = data/portfolios_DU111111.csv
+
+[portfolio:DU222222]
+path = data/portfolios_DU222222.csv
+```
+
+Accounts without an override use the global CSV.  Example run mixing global and
+per-account files:
+
+```bash
+python src/rebalance.py --config config/settings.ini --csv data/portfolios.csv
+```
+
 ## Usage
 
 ### Validate configuration

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -27,6 +27,10 @@ parallel = false
 ;cash_buffer_abs = 200
 ; Unspecified keys fall back to global values
 
+; Optional per-account portfolio CSV override
+[portfolio:DU111111]
+path = data/portfolios_DU111111.csv
+
 [models]
 ; Weight for SMURF model (0-1, weights must sum to 1.0)
 smurf = 0.50

--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -20,7 +20,12 @@ from .config_loader import (
     load_config,
     merge_account_overrides,
 )
-from .portfolio_csv import PortfolioCSVError, load_portfolios, validate_symbols
+from .portfolio_csv import (
+    PortfolioCSVError,
+    load_portfolios,
+    load_portfolios_map,
+    validate_symbols,
+)
 from .reporting import (
     append_run_summary,
     setup_logging,
@@ -44,6 +49,7 @@ __all__ = [
     "merge_account_overrides",
     "PortfolioCSVError",
     "load_portfolios",
+    "load_portfolios_map",
     "validate_symbols",
     "setup_logging",
     "write_pre_trade_report",

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -123,6 +123,7 @@ class AppConfig:
     io: IO
     accounts: Accounts
     account_overrides: Dict[str, AccountOverride] = field(default_factory=dict)
+    portfolio_paths: Dict[str, str] = field(default_factory=dict)
 
 
 TOLERANCE = 0.001
@@ -293,6 +294,15 @@ def load_config(path: Path) -> AppConfig:
             items = dict(cp.items(section))
             account_overrides[acc_id] = _parse_account_override(items)
 
+    portfolio_paths: Dict[str, str] = {}
+    for section in cp.sections():
+        if section.startswith("portfolio:"):
+            acc_id = section.split("portfolio:", 1)[1]
+            try:
+                portfolio_paths[acc_id] = cp.get(section, "path")
+            except NoOptionError as exc:
+                raise ConfigError(f"[{section}] missing key: path") from exc
+
     # [models]
     data = _load_section(cp, "models")
     required_models = ["smurf", "badass", "gltr"]
@@ -422,6 +432,7 @@ def load_config(path: Path) -> AppConfig:
         io=io_cfg,
         accounts=accounts,
         account_overrides=account_overrides,
+        portfolio_paths=portfolio_paths,
     )
 
 

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -28,8 +28,8 @@ class DummyClient:
         pass
 
 
-async def fake_load_portfolios(csv_path, host, port, client_id):  # noqa: ARG001
-    return {}
+async def fake_load_portfolios(path_map, host, port, client_id):  # noqa: ARG001
+    return {aid: {} for aid in path_map}
 
 
 async def stub_plan_account(

--- a/tests/unit/test_confirmation_independent.py
+++ b/tests/unit/test_confirmation_independent.py
@@ -21,8 +21,8 @@ class DummyClient:
         return {"positions": [], "cash": 0.0, "net_liq": 0.0}
 
 
-async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-    return {}
+async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+    return {aid: {} for aid in paths}
 
 
 def _patch_common(monkeypatch: pytest.MonkeyPatch, tmp_path, records, executed):

--- a/tests/unit/test_confirmation_modes.py
+++ b/tests/unit/test_confirmation_modes.py
@@ -22,8 +22,8 @@ class DummyClient:
         return {"positions": [], "cash": 0.0, "net_liq": 0.0}
 
 
-async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-    return {}
+async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+    return {aid: {} for aid in paths}
 
 
 def _patch_common(monkeypatch: pytest.MonkeyPatch, tmp_path):

--- a/tests/unit/test_multi_account_workflow.py
+++ b/tests/unit/test_multi_account_workflow.py
@@ -60,11 +60,12 @@ async def _run_rebalance(monkeypatch):
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _p: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-        return {
+    async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+        data = {
             "AAA": {"smurf": 0.5, "badass": 0.3, "gltr": 0.2},
             "BBB": {"smurf": 0.5, "badass": 0.3, "gltr": 0.2},
         }
+        return {aid: data for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 

--- a/tests/unit/test_rebalance_failures.py
+++ b/tests/unit/test_rebalance_failures.py
@@ -21,8 +21,8 @@ def _setup(monkeypatch: pytest.MonkeyPatch):
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _p: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-        return {}
+    async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+        return {aid: {} for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 

--- a/tests/unit/test_rebalance_faults.py
+++ b/tests/unit/test_rebalance_faults.py
@@ -26,8 +26,8 @@ def test_partial_account_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _p: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-        return {}
+    async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+        return {aid: {} for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 
@@ -97,8 +97,8 @@ def test_global_confirmation_pacing(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _p: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-        return {}
+    async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+        return {aid: {} for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 

--- a/tests/unit/test_rebalance_interrupt.py
+++ b/tests/unit/test_rebalance_interrupt.py
@@ -32,8 +32,8 @@ class DummyIBKRClient:
         raise KeyboardInterrupt
 
 
-async def fake_load_portfolios(path, *, host, port, client_id):  # noqa: ARG001
-    return {}
+async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+    return {aid: {} for aid in paths}
 
 
 def test_main_handles_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch, capsys):

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -32,11 +32,12 @@ def _setup_common(
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):
-        return {
+    async def fake_load_portfolios(paths, *, host, port, client_id):
+        data = {
             "AAA": {"smurf": 0.5, "badass": 0.3, "gltr": 0.2},
             "BBB": {"smurf": 0.5, "badass": 0.3, "gltr": 0.2},
         }
+        return {aid: data for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -32,8 +32,9 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch):
     )
     monkeypatch.setattr(rebalance, "load_config", lambda _: cfg)
 
-    async def fake_load_portfolios(path, *, host, port, client_id):
-        return {"AAA": {"smurf": 1.0, "badass": 0.0, "gltr": 0.0}}
+    async def fake_load_portfolios(paths, *, host, port, client_id):
+        data = {"AAA": {"smurf": 1.0, "badass": 0.0, "gltr": 0.0}}
+        return {aid: data for aid in paths}
 
     monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
 


### PR DESCRIPTION
## Summary
- allow per-account portfolio CSV overrides via `[portfolio:<ID>]` sections
- load portfolios per account with schema validation
- document account-specific portfolio files in README

## Testing
- `pytest -q`
- `pre-commit run --files README.md config/settings.ini src/io/__init__.py src/io/config_loader.py src/io/portfolio_csv.py src/rebalance.py tests/integration/test_parallel_accounts.py tests/unit/test_confirmation_independent.py tests/unit/test_confirmation_modes.py tests/unit/test_multi_account_workflow.py tests/unit/test_rebalance_failures.py tests/unit/test_rebalance_faults.py tests/unit/test_rebalance_interrupt.py tests/unit/test_rebalance_pricing.py tests/unit/test_rebalance_submit.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba2ec8622883209049dcb93c39359c