### PR TITLE
Refactor parallel account task scheduling

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -143,13 +143,13 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
         tasks: list[asyncio.Task] = []
         task_accounts: list[str] = []
         pacing = getattr(accounts, "pacing_sec", 0.0)
+
+        async def start_after_delay(aid: str, delay: float) -> Plan | None:
+            if delay:
+                await asyncio.sleep(delay)
+            return await handle_account(aid)
+
         for idx, account_id in enumerate(accounts.ids):
-
-            async def start_after_delay(aid: str, delay: float) -> Plan | None:
-                if delay:
-                    await asyncio.sleep(delay)
-                return await handle_account(aid)
-
             tasks.append(
                 asyncio.create_task(start_after_delay(account_id, idx * pacing))
             )


### PR DESCRIPTION
## Summary
- Move async helper `start_after_delay` outside loop to avoid redefinition
- Schedule account handling tasks using `asyncio.create_task`

## Testing
- `pytest tests/integration/test_parallel_accounts.py::test_parallel_accounts -q -m integration`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba3634c68c8320b47d2454be69385d