### PR TITLE
Apply per-account overrides during confirmation

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -28,6 +28,7 @@ async def confirm_per_account(
     size_orders,
 ) -> None:
     """Handle confirmation, execution, and reporting for a single account."""
+    cfg = merge_account_overrides(cfg, plan["account_id"])
 
     account_id = plan["account_id"]
     trades = plan["trades"]

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -98,7 +98,7 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                 await confirm_per_account(
                     plan,
                     args,
-                    cfg_acct,
+                    cfg,
                     ts_dt,
                     client_factory=IBKRClient,
                     submit_batch=submit_batch,
@@ -197,11 +197,10 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
         for plan in plans:
             account_id = plan["account_id"]
             try:
-                cfg_acct = merge_account_overrides(cfg, account_id)
                 await confirm_per_account(
                     plan,
                     args,
-                    cfg_acct,
+                    cfg,
                     ts_dt,
                     client_factory=IBKRClient,
                     submit_batch=submit_batch,


### PR DESCRIPTION
## Summary
- merge account overrides inside `confirm_per_account` so callers can pass base config
- drop redundant merges in `rebalance` when invoking `confirm_per_account`
- test that account-specific `min_order_usd` overrides are honored

## Testing
- `pre-commit run --files src/core/confirmation.py src/rebalance.py tests/unit/test_confirm_per_account.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba38f280088320b648d03afc1027dc