### PR TITLE
Add per-account confirmation pacing

### DIFF
--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -5,13 +5,13 @@ This module parses ``settings.ini`` files into structured dataclasses.
 
 from __future__ import annotations
 
+import logging
 from configparser import ConfigParser, NoOptionError, NoSectionError
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, Mapping
-import logging
 
 
 class ConfigError(Exception):

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -232,6 +232,8 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                         "error": str(exc),
                     },
                 )
+            finally:
+                await asyncio.sleep(getattr(accounts, "pacing_sec", 0))
 
     if confirm_mode is ConfirmMode.GLOBAL:
         plans.sort(key=lambda p: str(p["account_id"]))

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,6 +1,6 @@
+import logging
 import sys
 from pathlib import Path
-import logging
 
 import pytest
 


### PR DESCRIPTION
## Summary
- ensure per-account confirmation loops respect pacing by sleeping after each attempt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba3ed4d5548320b907b229483fbbf3