### PR TITLE
Align stub_confirm_per_account with real function signature

### DIFF
--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -71,6 +71,7 @@ async def stub_confirm_per_account(
     compute_drift,  # noqa: ARG002
     prioritize_by_drift,  # noqa: ARG002
     size_orders,  # noqa: ARG002
+    output_lock=None,  # noqa: ARG002
 ):
     confirm_starts.append(time.perf_counter())
     client_factory()


### PR DESCRIPTION
## Summary
- accept optional output_lock in test stub_confirm_per_account to mirror real confirm_per_account

## Testing
- `PYTHONPATH=. pytest tests/integration/test_parallel_accounts.py::test_parallel_accounts -q -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68ba49140d288320a8f657f9c7bac557