### PR TITLE
Use rich printing in confirmation

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
+from rich import print
+
 from src.broker.errors import IBKRError
 from src.broker.ibkr_client import IBKRClient
 from src.core.errors import PlanningError


### PR DESCRIPTION
## Summary
- switch confirmation workflow to use Rich's `print` for colored terminal output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba499b4fd083208cf0e638e5394f07