### PR TITLE
Ensure parallel account output lock initialized

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -75,7 +75,7 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
     confirm_mode = getattr(accounts, "confirm_mode", ConfirmMode.PER_ACCOUNT)
 
     output_lock: asyncio.Lock | None = None
-    if args.yes and getattr(accounts, "parallel", False):
+    if getattr(accounts, "parallel", False):
         output_lock = asyncio.Lock()
 
     async def handle_account(account_id: str) -> Plan | None:

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -73,6 +73,7 @@ async def stub_confirm_per_account(
     size_orders,  # noqa: ARG002
     output_lock=None,  # noqa: ARG002
 ):
+    assert output_lock is not None
     confirm_starts.append(time.perf_counter())
     client_factory()
     await asyncio.sleep(0.1)


### PR DESCRIPTION
## Summary
- Create an output lock whenever accounts are processed in parallel, independent of `--yes`
- Ensure integration test confirms lock presence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4c04014c8320b20acdfe370a9ab4