### PR TITLE
Handle parallel task exceptions in rebalance summary

### DIFF
--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -207,6 +207,25 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                         print(f"[red]{res}[/red]")
                 else:
                     print(f"[red]{res}[/red]")
+                failures.append((aid, str(res)))
+                capture_summary(
+                    Path(cfg.io.report_dir),
+                    ts_dt,
+                    {
+                        "timestamp_run": ts_dt.isoformat(),
+                        "account_id": aid,
+                        "planned_orders": 0,
+                        "submitted": 0,
+                        "filled": 0,
+                        "rejected": 0,
+                        "buy_usd": 0.0,
+                        "sell_usd": 0.0,
+                        "pre_leverage": 0.0,
+                        "post_leverage": 0.0,
+                        "status": "failed",
+                        "error": str(res),
+                    },
+                )
             elif res is not None:
                 plans.append(res)
     else:

--- a/tests/unit/test_rebalance_failures.py
+++ b/tests/unit/test_rebalance_failures.py
@@ -142,3 +142,99 @@ def test_parallel_task_exception_records_failure(
     assert failures == [("bad", "kaboom")]
     assert statuses["good"] == "dry_run"
     assert statuses["bad"] == "failed"
+
+
+def test_parallel_sleep_exception_records_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = SimpleNamespace(
+        ibkr=SimpleNamespace(host="h", port=1, client_id=1, read_only=False),
+        models=SimpleNamespace(smurf=0.5, badass=0.3, gltr=0.2),
+        pricing=SimpleNamespace(price_source="last", fallback_to_snapshot=True),
+        execution=SimpleNamespace(
+            order_type="MKT", algo_preference="adaptive", commission_report_timeout=5.0
+        ),
+        io=SimpleNamespace(report_dir="reports", log_level="INFO"),
+        accounts=SimpleNamespace(ids=["good", "bad"], parallel=True, pacing_sec=1.0),
+    )
+    monkeypatch.setattr(rebalance, "load_config", lambda _p: cfg)
+
+    async def fake_load_portfolios(paths, *, host, port, client_id):  # noqa: ARG001
+        return {aid: {} for aid in paths}
+
+    monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
+
+    async def fake_plan_account(account_id, portfolios, cfg_acct, ts_dt, **kwargs):
+        return {
+            "account_id": account_id,
+            "planned_orders": 0,
+            "buy_usd": 0.0,
+            "sell_usd": 0.0,
+            "pre_leverage": 0.0,
+        }
+
+    monkeypatch.setattr(rebalance, "plan_account", fake_plan_account)
+    monkeypatch.setattr(rebalance, "setup_logging", lambda *a, **k: None)
+
+    async def fake_confirm_per_account(
+        plan,
+        args,
+        cfg,
+        ts_dt,
+        *,
+        client_factory,
+        submit_batch,
+        append_run_summary,
+        write_post_trade_report,
+        compute_drift,
+        prioritize_by_drift,
+        size_orders,
+        output_lock,
+    ):
+        append_run_summary(
+            Path(cfg.io.report_dir),
+            ts_dt,
+            {
+                "timestamp_run": ts_dt.isoformat(),
+                "account_id": plan["account_id"],
+                "planned_orders": plan["planned_orders"],
+                "submitted": 0,
+                "filled": 0,
+                "rejected": 0,
+                "buy_usd": plan["buy_usd"],
+                "sell_usd": plan["sell_usd"],
+                "pre_leverage": plan["pre_leverage"],
+                "post_leverage": plan["pre_leverage"],
+                "status": "dry_run",
+            },
+        )
+
+    monkeypatch.setattr(rebalance, "confirm_per_account", fake_confirm_per_account)
+
+    sleep_calls = 0
+
+    async def fake_sleep(delay):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if delay and sleep_calls == 1:
+            raise RuntimeError("boom")
+        return None
+
+    monkeypatch.setattr(rebalance.asyncio, "sleep", fake_sleep)
+
+    rows: dict[str, dict[str, object]] = {}
+
+    def fake_append_run_summary(path, ts_dt, data):  # noqa: ARG001
+        rows[data["account_id"]] = data
+
+    monkeypatch.setattr(rebalance, "append_run_summary", fake_append_run_summary)
+
+    args = argparse.Namespace(
+        config="cfg", csv="csv", dry_run=True, yes=False, read_only=False
+    )
+
+    failures = asyncio.run(rebalance._run(args))
+    assert failures == [("bad", "boom")]
+    assert rows["good"]["status"] == "dry_run"
+    assert rows["bad"]["status"] == "failed"
+    assert rows["bad"]["planned_orders"] == 0


### PR DESCRIPTION
## Summary
- Track failures when parallel account tasks raise exceptions
- Log a failed summary row with zeroed metrics for such exceptions
- Test that parallel task exceptions are reported and summarized

## Testing
- `pre-commit run --files src/rebalance.py tests/unit/test_rebalance_failures.py`
- `PYTHONPATH=. pytest tests/unit/test_rebalance_failures.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4e7446208320833f133f97a27c2a