### PR TITLE
Document parallel prompt behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Displays the batch summary and exits without placing orders.
 When `[accounts]` lists more than one ID, the rebalancer previews each
 account in sequence. Run the same command to simulate the batch, or add
 `--parallel-accounts` to process them concurrently. Per-account confirmations
-remain serialized so prompts appear one at a time:
+remain serialized without `--yes` so prompts appear one at a time:
 
 ```bash
 python src/rebalance.py --dry-run --parallel-accounts --config config/settings.ini --csv data/portfolios.csv

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -374,7 +374,10 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--parallel-accounts",
         action="store_true",
-        help="Plan and execute accounts concurrently",
+        help=(
+            "Plan and execute accounts concurrently; prompts remain serialized "
+            "without --yes"
+        ),
     )
     args = parser.parse_args(argv if argv is not None else [])
 


### PR DESCRIPTION
## Summary
- clarify that concurrent accounts still serialize prompts without --yes
- note the same behavior in README usage example

## Testing
- `pre-commit run --files src/rebalance.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba581cb1f88320bc547fc2de463617