### PR TITLE
Clarify account confirmation behavior

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -17,7 +17,7 @@ ids = DU111111, DU222222
 confirm_mode = per_account
 ; Minimum seconds between account operations (0 disables pacing)
 pacing_sec = 5
-; Process accounts concurrently when true (per-account confirmations remain serialized)
+; Process accounts concurrently when true; confirmations serialize only when prompts are shown (i.e., without --yes)
 parallel = false
 
 ; Example per-account overrides


### PR DESCRIPTION
## Summary
- clarify that confirmations serialize only when prompts are shown in `[accounts]` parallel setting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba67b55f5c8320a7aa73fe597e0886