### PR TITLE
validate portfolio account ids against accounts list

### DIFF
--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -310,6 +310,12 @@ def load_config(path: Path) -> AppConfig:
             except NoOptionError as exc:
                 raise ConfigError(f"[{section}] missing key: path") from exc
 
+    unknown_accounts = sorted(set(portfolio_paths) - set(accounts.ids))
+    if unknown_accounts:
+        raise ConfigError(
+            "[portfolio] unknown account ids: " + ", ".join(unknown_accounts)
+        )
+
     # [models]
     data = _load_section(cp, "models")
     required_models = ["smurf", "badass", "gltr"]

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -264,3 +264,12 @@ def test_account_id_normalization(tmp_path: Path) -> None:
     assert cfg.portfolio_paths["ACC1"] == "foo.csv"
     cfg_acc = merge_account_overrides(cfg, "acc2")
     assert cfg_acc.rebalance.min_order_usd == 100
+
+
+def test_portfolio_override_unknown_account(tmp_path: Path) -> None:
+    content = VALID_CONFIG + "\n[portfolio: acc3 ]\npath = foo.csv\n"
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    with pytest.raises(ConfigError) as exc:
+        load_config(path)
+    assert "ACC3" in str(exc.value)


### PR DESCRIPTION
## Summary
- validate portfolio overrides against known account IDs
- test that unknown portfolio account IDs raise ConfigError

## Testing
- `pytest tests/unit/test_config_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c17bc6c8320a21e64992e5c7cd8