### PR TITLE
Normalize portfolio section names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ $10 while all other accounts require whole-share orders of at least $50.
 ### Per-account portfolio files
 
 By default all accounts share the CSV passed via `--csv`.  Specify a separate
-portfolio for an account using `[portfolio:<ID>]` blocks:
+portfolio for an account using `[portfolio:<ID>]` blocks. Section names are
+case-insensitive, so `[Portfolio:<ID>]` is also accepted:
 
 ```ini
 [portfolio:DU111111]

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -303,8 +303,8 @@ def load_config(path: Path) -> AppConfig:
 
     portfolio_paths: Dict[str, Path] = {}
     for section in cp.sections():
-        if section.startswith("portfolio:"):
-            acc_id = section.split("portfolio:", 1)[1].strip().upper()
+        if section.lower().startswith("portfolio:"):
+            acc_id = section.split(":", 1)[1].strip().upper()
             try:
                 portfolio_paths[acc_id] = Path(cp.get(section, "path"))
             except NoOptionError as exc:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -68,7 +68,7 @@ log_level = INFO
 """
 
 
-VALID_CONFIG_WITH_PORTFOLIO = VALID_CONFIG + "\n[portfolio: acc1 ]\npath = foo.csv\n"
+VALID_CONFIG_WITH_PORTFOLIO = VALID_CONFIG + "\n[Portfolio: acc1 ]\npath = foo.csv\n"
 
 
 @pytest.fixture
@@ -272,7 +272,7 @@ def test_account_id_normalization(tmp_path: Path) -> None:
         "ids = acc1 , Acc2 ",
     )
     content += (
-        "\n[portfolio: acc1 ]\npath = foo.csv\n[account: Acc2]\nmin_order_usd = 100\n"
+        "\n[Portfolio: acc1 ]\npath = foo.csv\n[account: Acc2]\nmin_order_usd = 100\n"
     )
     path = tmp_path / "settings.ini"
     path.write_text(content)
@@ -284,7 +284,7 @@ def test_account_id_normalization(tmp_path: Path) -> None:
 
 
 def test_portfolio_override_unknown_account(tmp_path: Path) -> None:
-    content = VALID_CONFIG_WITH_PORTFOLIO + "\n[portfolio: acc3 ]\npath = foo.csv\n"
+    content = VALID_CONFIG_WITH_PORTFOLIO + "\n[Portfolio: acc3 ]\npath = foo.csv\n"
     path = tmp_path / "settings.ini"
     path.write_text(content)
     with pytest.raises(ConfigError) as exc:


### PR DESCRIPTION
## Summary
- allow `[Portfolio:...]` sections by checking portfolio prefixes case-insensitively
- test config loader with mixed-case `[Portfolio:...]` blocks
- document case-insensitive section names

## Testing
- `pytest tests/unit/test_config_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba7077e418832089b43d97d86a5db0