### PR TITLE
Resolve per-account portfolio paths relative to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ $10 while all other accounts require whole-share orders of at least $50.
 
 ### Per-account portfolio files
 
-By default all accounts share the CSV passed via `--csv`.  Specify a separate
+By default all accounts share the CSV passed via `--csv`. Specify a separate
 portfolio for an account using `[portfolio:<ID>]` blocks. Section names are
-case-insensitive, so `[Portfolio:<ID>]` is also accepted:
+case-insensitive, so `[Portfolio:<ID>]` is also accepted. Paths here are
+resolved relative to the directory containing `settings.ini`:
 
 ```ini
 [portfolio:DU111111]
-path = data/portfolios_DU111111.csv
+path = data/portfolios_DU111111.csv  # relative to settings.ini
 
 [portfolio:DU222222]
 path = data/portfolios_DU222222.csv

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -223,6 +223,8 @@ def load_config(path: Path) -> AppConfig:
     if not cp.read(path):
         raise ConfigError(f"Cannot read config: {path}")
 
+    base_dir = path.parent
+
     # [ibkr]
     try:
         host = cp.get("ibkr", "host")
@@ -306,7 +308,8 @@ def load_config(path: Path) -> AppConfig:
         if section.lower().startswith("portfolio:"):
             acc_id = section.split(":", 1)[1].strip().upper()
             try:
-                portfolio_paths[acc_id] = Path(cp.get(section, "path"))
+                raw_path = Path(cp.get(section, "path"))
+                portfolio_paths[acc_id] = (base_dir / raw_path).resolve()
             except NoOptionError as exc:
                 raise ConfigError(f"[{section}] missing key: path") from exc
 


### PR DESCRIPTION
## Summary
- Resolve portfolio paths against the directory of the loaded config file
- Support using relative portfolio overrides from any working directory
- Clarify README on how `[portfolio:<ID>]` paths are resolved

## Testing
- `pre-commit run --files README.md src/io/config_loader.py tests/unit/test_config_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba7138b59c8320ac73ae4d9be77282