### PR TITLE
Handle case-insensitive account override sections

### DIFF
--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -298,8 +298,8 @@ def load_config(path: Path) -> AppConfig:
 
     account_overrides: Dict[str, AccountOverride] = {}
     for section in cp.sections():
-        if section.startswith("account:"):
-            acc_id = section.split("account:", 1)[1].strip().upper()
+        if section.lower().startswith("account:"):
+            acc_id = section.split(":", 1)[1].strip().upper()
             items = dict(cp.items(section))
             account_overrides[acc_id] = _parse_account_override(items)
 

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -295,6 +295,16 @@ def test_account_overrides_min_order_usd(tmp_path: Path) -> None:
     assert cfg_acc.rebalance.min_order_usd == 100
 
 
+def test_account_section_case_insensitive(tmp_path: Path) -> None:
+    content = VALID_CONFIG + "\n[Account: acc1 ]\nmin_order_usd = 100\n"
+    path = tmp_path / "settings.ini"
+    path.write_text(content)
+    cfg = load_config(path)
+    assert cfg.rebalance.min_order_usd == 500
+    cfg_acc = merge_account_overrides(cfg, "acc1")
+    assert cfg_acc.rebalance.min_order_usd == 100
+
+
 def test_account_overrides_cash_buffer_abs(tmp_path: Path) -> None:
     content = (
         VALID_CONFIG


### PR DESCRIPTION
## Summary
- recognize account override sections regardless of case
- test that [Account:ID] sections apply overrides

## Testing
- `pytest tests/unit/test_config_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba75a1b22c832089ba084704e1baae