### PR TITLE
Resolve portfolio CSV path caching

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -179,7 +179,9 @@ async def load_portfolios_map(
     result: Dict[str, dict[str, dict[str, float]]] = {}
     symbols: set[str] = set()
     for account, p in paths.items():
-        path = Path(p)
+        # Resolve the path so that different references (relative vs. absolute)
+        # to the same file map to a single cache entry.
+        path = Path(p).resolve()
         data = cache.get(path)
         if data is None:
             portfolios, expected = _parse_csv(path, expected)


### PR DESCRIPTION
## Summary
- normalize portfolio CSV paths with `resolve()` before caching
- test cache behavior with relative and absolute file references

## Testing
- `pytest tests/unit/test_portfolio_csv.py::test_load_portfolios_map_relative_and_absolute -q`
- `pytest tests/unit/test_portfolio_csv.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba763b7984832087c624aa845d8253