### PR TITLE
feat: validate multiple portfolio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,13 @@ python -m src.io.validate_config config/settings.ini
 ```
 
 ### Validate portfolio CSV
+Validate a single CSV:
 ```bash
 python -m src.io.validate_portfolios --config config/settings.ini data/portfolios.csv
+```
+Validate all portfolio files including account-specific overrides:
+```bash
+python -m src.io.validate_portfolios --config config/settings.ini --all data/portfolios.csv
 ```
 An active IBKR session (TWS or IB Gateway) must be running so the tool can
 verify ticker symbols.

--- a/src/io/validate_portfolios.py
+++ b/src/io/validate_portfolios.py
@@ -6,11 +6,22 @@ import asyncio
 from pathlib import Path
 
 from .config_loader import ConfigError, load_config
-from .portfolio_csv import PortfolioCSVError, load_portfolios
+from .portfolio_csv import PortfolioCSVError, load_portfolios, load_portfolios_map
 
 
-async def main(path: str, *, config_path: str) -> None:
-    """Validate and load ``path`` printing ``OK`` on success."""
+async def main(path: str, *, config_path: str, validate_all: bool = False) -> None:
+    """Validate portfolio CSVs printing ``OK`` on success.
+
+    Parameters
+    ----------
+    path:
+        Global portfolio CSV shared across accounts.
+    config_path:
+        Path to ``settings.ini``.
+    validate_all:
+        When ``True``, validate the global CSV plus any per-account
+        overrides found in the configuration.
+    """
 
     try:
         cfg = load_config(Path(config_path))
@@ -19,12 +30,24 @@ async def main(path: str, *, config_path: str) -> None:
         raise SystemExit(1)
 
     try:
-        await load_portfolios(
-            Path(path),
-            host=cfg.ibkr.host,
-            port=cfg.ibkr.port,
-            client_id=cfg.ibkr.client_id,
-        )
+        if validate_all:
+            path_map = {
+                acct: cfg.portfolio_paths.get(acct, Path(path))
+                for acct in cfg.accounts.ids
+            }
+            await load_portfolios_map(
+                path_map,
+                host=cfg.ibkr.host,
+                port=cfg.ibkr.port,
+                client_id=cfg.ibkr.client_id,
+            )
+        else:
+            await load_portfolios(
+                Path(path),
+                host=cfg.ibkr.host,
+                port=cfg.ibkr.port,
+                client_id=cfg.ibkr.client_id,
+            )
     except PortfolioCSVError as exc:
         print(exc)
         raise SystemExit(1)
@@ -37,5 +60,10 @@ if __name__ == "__main__":  # pragma: no cover - CLI utility
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("csv_path", help="Portfolio CSV to validate")
     parser.add_argument("--config", required=True, help="Path to settings.ini")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Validate the global CSV plus any per-account overrides",
+    )
     args = parser.parse_args()
-    asyncio.run(main(args.csv_path, config_path=args.config))
+    asyncio.run(main(args.csv_path, config_path=args.config, validate_all=args.all))

--- a/tests/unit/test_validate_portfolios_cli.py
+++ b/tests/unit/test_validate_portfolios_cli.py
@@ -41,3 +41,45 @@ def test_cli_error(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "Missing columns" in result.stdout
+
+
+def test_cli_all_ok(tmp_path: Path) -> None:
+    global_csv = tmp_path / "pf.csv"
+    global_csv.write_text("ETF,SMURF,BADASS,GLTR\nCASH,100%,100%,100%\n")
+    cfg = Path(__file__).resolve().parents[2] / "config" / "settings.ini"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.io.validate_portfolios",
+            "--config",
+            str(cfg),
+            "--all",
+            str(global_csv),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "OK"
+
+
+def test_cli_all_error(tmp_path: Path) -> None:
+    global_csv = tmp_path / "pf.csv"
+    global_csv.write_text("ETF,SMURF,BADASS\nCASH,100%,100%\n")
+    cfg = Path(__file__).resolve().parents[2] / "config" / "settings.ini"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.io.validate_portfolios",
+            "--config",
+            str(cfg),
+            "--all",
+            str(global_csv),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Missing columns" in result.stdout


### PR DESCRIPTION
## Summary
- allow CLI to validate global and account-specific portfolio CSVs
- document new --all flag and add multi-file tests

## Testing
- `pre-commit run --files README.md src/io/validate_portfolios.py tests/unit/test_validate_portfolios_cli.py`
- `pytest tests/unit/test_validate_portfolios_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba778dbf808320a4abc9d8959e4b3d