### PR TITLE
Clarify global CSV requirement for portfolio validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ path = data/portfolios_DU111111.csv  # relative to settings.ini
 path = data/portfolios_DU222222.csv
 ```
 
-Accounts without an override use the global CSV.  Example run mixing global and
-per-account files:
+Accounts without an override use the global CSV. `validate_portfolios --all`
+needs a valid global CSV unless every account has an override. Example run
+mixing global and per-account files:
 
 ```bash
 python src/rebalance.py --config config/settings.ini --csv data/portfolios.csv


### PR DESCRIPTION
## Summary
- Clarify that `validate_portfolios --all` requires a valid global CSV unless each account provides an override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d7699cc8320b9f697e7f5e21ed4