### PR TITLE
Test validate_portfolios CLI processes account overrides

### DIFF
--- a/tests/unit/test_validate_portfolios_cli.py
+++ b/tests/unit/test_validate_portfolios_cli.py
@@ -1,6 +1,14 @@
+import asyncio
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import src.io.portfolio_csv as portfolio_csv
+import src.io.validate_portfolios as validate_portfolios
 
 
 def test_cli_ok(tmp_path: Path) -> None:
@@ -83,3 +91,85 @@ def test_cli_all_error(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "Missing columns" in result.stdout
+
+
+def test_cli_all_reads_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure global and account-specific portfolio files are processed."""
+
+    config_text = """\
+[ibkr]
+host = 127.0.0.1
+port = 4002
+client_id = 42
+read_only = true
+
+[accounts]
+ids = ACC1, ACC2
+confirm_mode = per_account
+
+[models]
+smurf = 0.50
+badass = 0.30
+gltr = 0.20
+
+[rebalance]
+trigger_mode = per_holding
+per_holding_band_bps = 50
+portfolio_total_band_bps = 100
+min_order_usd = 500
+cash_buffer_type = pct
+cash_buffer_pct = 0.01
+cash_buffer_abs = 0
+allow_fractional = false
+max_leverage = 1.50
+maintenance_buffer_pct = 0.10
+trading_hours = rth
+max_passes = 3
+
+[pricing]
+price_source = last
+fallback_to_snapshot = true
+
+[execution]
+order_type = market
+algo_preference = adaptive
+fallback_plain_market = true
+batch_orders = true
+commission_report_timeout = 5.0
+wait_before_fallback = 300
+
+[io]
+report_dir = reports
+log_level = INFO
+
+[portfolio:acc1]
+path = acc1.csv
+"""
+
+    cfg_path = tmp_path / "settings.ini"
+    cfg_path.write_text(config_text)
+
+    global_csv = tmp_path / "global.csv"
+    global_csv.write_text("ETF,SMURF,BADASS,GLTR\nCASH,100%,100%,100%\n")
+    acct_csv = tmp_path / "acc1.csv"
+    acct_csv.write_text("ETF,SMURF,BADASS,GLTR\nCASH,100%,100%,100%\n")
+
+    seen: list[Path] = []
+
+    orig_parse = portfolio_csv._parse_csv
+
+    def fake_parse(path: Path, expected: list[str] | None = None):
+        seen.append(Path(path).resolve())
+        return orig_parse(path, expected)
+
+    monkeypatch.setattr(portfolio_csv, "_parse_csv", fake_parse)
+
+    asyncio.run(
+        validate_portfolios.main(
+            str(global_csv), config_path=str(cfg_path), validate_all=True
+        )
+    )
+
+    assert {global_csv.resolve(), acct_csv.resolve()} == set(seen)


### PR DESCRIPTION
## Summary
- add unit test to confirm validate_portfolios reads both global and account-specific CSVs when `--all` is used

## Testing
- `pre-commit run --files tests/unit/test_validate_portfolios_cli.py`
- `pytest tests/unit/test_validate_portfolios_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba7dad3b848320ab7fd9d84d8f88f4