### PR TITLE
Use async IB disconnect in symbol validation

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -75,17 +75,10 @@ async def validate_symbols(
             if contract is None or contract.currency != "USD" or cd.stockType != "ETF":
                 raise PortfolioCSVError(f"{symbol}: not a USD-denominated ETF")
     finally:
-        is_connected = getattr(ib, "isConnected", None)
         try:
-            connected = (
-                is_connected()
-                if callable(is_connected)
-                else getattr(ib, "connected", False)
-            )
+            await ib.disconnectAsync()
         except Exception:
-            connected = getattr(ib, "connected", False)
-        if connected:
-            ib.disconnect()
+            pass
 
 
 async def load_portfolios(


### PR DESCRIPTION
## Summary
- replace sync `disconnect` with awaited `disconnectAsync` in symbol validation
- ignore harmless disconnect errors
- extend unit tests to verify async disconnect and error handling

## Testing
- `pytest tests/unit/test_validate_symbols.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba7ed86a508320aa2e136bd0f8da86