### PR TITLE
Ensure duplicate CSV headers are reported once

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -119,8 +119,10 @@ def _parse_csv(
             raise PortfolioCSVError("Missing header")
         field_list = list(fieldnames)
         if len(field_list) != len(set(field_list)):
-            dupes = [n for n in field_list if field_list.count(n) > 1]
-            raise PortfolioCSVError(f"Duplicate columns: {', '.join(dupes)}")
+            dupes = {n for n in field_list if field_list.count(n) > 1}
+            raise PortfolioCSVError(
+                f"Duplicate columns: {', '.join(sorted(dupes))}"
+            )
         exp = expected or field_list
         if set(field_list) != set(exp):
             extra = set(field_list) - set(exp)

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -146,6 +146,18 @@ BLOK,0%,0%,0%
         asyncio.run(load_portfolios(path, host="127.0.0.1", port=4001, client_id=1))
 
 
+def test_duplicate_columns_once(tmp_path: Path) -> None:
+    content = """ETF,SMURF,BADASS,SMURF,BADASS
+BLOK,0%,0%,0%,0%
+"""
+    path = tmp_path / "pf.csv"
+    path.write_text(content)
+    with pytest.raises(
+        PortfolioCSVError, match=r"Duplicate columns: BADASS, SMURF"
+    ):
+        asyncio.run(load_portfolios(path, host="127.0.0.1", port=4001, client_id=1))
+
+
 @pytest.mark.parametrize(
     "value,expected",
     [


### PR DESCRIPTION
## Summary
- dedupe CSV column headers with a set and sort for error messages
- add regression test covering multiple duplicated headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba7ee3ef908320b24eb26cf8f40840