### PR TITLE
Display missing account IDs in portfolio CSV validation

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -113,9 +113,7 @@ def _parse_csv(
         field_list = list(fieldnames)
         if len(field_list) != len(set(field_list)):
             dupes = {n for n in field_list if field_list.count(n) > 1}
-            raise PortfolioCSVError(
-                f"Duplicate columns: {', '.join(sorted(dupes))}"
-            )
+            raise PortfolioCSVError(f"Duplicate columns: {', '.join(sorted(dupes))}")
         exp = expected or field_list
         if set(field_list) != set(exp):
             extra = set(field_list) - set(exp)

--- a/src/io/validate_portfolios.py
+++ b/src/io/validate_portfolios.py
@@ -9,7 +9,9 @@ from .config_loader import ConfigError, load_config
 from .portfolio_csv import PortfolioCSVError, load_portfolios, load_portfolios_map
 
 
-async def main(path: str | None = None, *, config_path: str, validate_all: bool = False) -> None:
+async def main(
+    path: str | None = None, *, config_path: str, validate_all: bool = False
+) -> None:
     """Validate portfolio CSVs printing ``OK`` on success.
 
     Parameters
@@ -37,14 +39,20 @@ async def main(path: str | None = None, *, config_path: str, validate_all: bool 
         if validate_all or all_have_paths:
             if not all_have_paths:
                 if path is None:
-                    print("CSV path required for accounts without overrides")
+                    missing_ids = ", ".join(missing)
+                    print(
+                        "CSV path required for accounts without overrides: "
+                        f"{missing_ids}"
+                    )
                     raise SystemExit(1)
                 path_map = {
                     acct: cfg.portfolio_paths.get(acct, Path(path))
                     for acct in cfg.accounts.ids
                 }
             else:
-                path_map = {acct: cfg.portfolio_paths[acct] for acct in cfg.accounts.ids}
+                path_map = {
+                    acct: cfg.portfolio_paths[acct] for acct in cfg.accounts.ids
+                }
             await load_portfolios_map(
                 path_map,
                 host=cfg.ibkr.host,

--- a/tests/integration/test_confirm_global_parallel.py
+++ b/tests/integration/test_confirm_global_parallel.py
@@ -214,6 +214,7 @@ def test_confirm_global_yes_flag_disables_parallelism(monkeypatch, cfg):
     monkeypatch.setattr(
         "src.core.confirmation.confirm_per_account", stub_confirm_per_account
     )
+
     async def fake_prompt(*a, **k):
         return "y"
 

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -92,7 +92,9 @@ def test_yes_skips_prompt(
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
 
-    async def fail_prompt(*args, **kwargs) -> str:  # pragma: no cover - should not be called
+    async def fail_prompt(
+        *args, **kwargs
+    ) -> str:  # pragma: no cover - should not be called
         raise AssertionError("prompt should not be invoked when --yes is used")
 
     monkeypatch.setattr("src.core.confirmation._prompt_user", fail_prompt)
@@ -168,7 +170,9 @@ def test_yes_skips_prompt_global(
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
 
-    async def fail_prompt(*args, **kwargs) -> str:  # pragma: no cover - should not be called
+    async def fail_prompt(
+        *args, **kwargs
+    ) -> str:  # pragma: no cover - should not be called
         raise AssertionError("prompt should not be invoked when --yes is used")
 
     monkeypatch.setattr("src.core.confirmation._prompt_user", fail_prompt)

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -152,9 +152,7 @@ BLOK,0%,0%,0%,0%
 """
     path = tmp_path / "pf.csv"
     path.write_text(content)
-    with pytest.raises(
-        PortfolioCSVError, match=r"Duplicate columns: BADASS, SMURF"
-    ):
+    with pytest.raises(PortfolioCSVError, match=r"Duplicate columns: BADASS, SMURF"):
         asyncio.run(load_portfolios(path, host="127.0.0.1", port=4001, client_id=1))
 
 


### PR DESCRIPTION
## Summary
- list account IDs missing portfolio CSV overrides
- show missing account IDs in error message when CSV path is required

## Testing
- `pre-commit run --files src/io/validate_portfolios.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baecdd67f483209e90b399643bc39c