### PR TITLE
Handle zero-fill when computing average price

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -159,13 +159,19 @@ async def submit_batch(
                 getattr(fallback_trade.orderStatus, "avgFillPrice", 0.0)
             )
             filled = filled_first + filled_second
-            avg_price = (
-                (filled_first * avg_price_first) + (filled_second * avg_price_second)
-            ) / filled
+            if filled > 0:
+                avg_price = (
+                    (filled_first * avg_price_first)
+                    + (filled_second * avg_price_second)
+                ) / filled
+            else:
+                avg_price = 0.0  # safeguard: avoid division when nothing filled
             exec_objs.append(fallback_trade)
         else:
             filled = filled_first
-            avg_price = avg_price_first
+            avg_price = (
+                avg_price_first if filled_first > 0 else 0.0
+            )  # safeguard for zero fill
 
         commission_placeholder = False
         exec_commissions: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- guard `submit_batch` avg price calculation against zero total fill

## Testing
- `PYTHONPATH=. pytest tests/unit/test_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_68baef8b18448320876ffa14873ed392