### PR TITLE
Resolve portfolio CSV paths relative to config

### DIFF
--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -117,7 +117,7 @@ def test_parallel_accounts(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -161,7 +161,7 @@ def test_parallel_confirmation_overlap(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=True,
         read_only=False,
@@ -219,7 +219,7 @@ def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -297,7 +297,7 @@ def test_serialized_planner_output(monkeypatch, capsys, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=True,
         read_only=False,

--- a/tests/integration/test_parallel_pacing.py
+++ b/tests/integration/test_parallel_pacing.py
@@ -112,7 +112,7 @@ def test_parallel_pacing(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -70,7 +70,7 @@ def test_prompt_default(
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -114,7 +114,7 @@ def test_yes_skips_prompt(
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=True,
         read_only=False,
@@ -147,7 +147,7 @@ def test_prompt_global(
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -192,7 +192,7 @@ def test_yes_skips_prompt_global(
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=True,
         read_only=False,

--- a/tests/integration/test_rebalance_dry_run.py
+++ b/tests/integration/test_rebalance_dry_run.py
@@ -58,7 +58,7 @@ def test_rebalance_dry_run(monkeypatch, capsys):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -89,7 +89,7 @@ def test_rebalance_multiple_accounts_failure(monkeypatch, capsys):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/integration/test_run_summary.py
+++ b/tests/integration/test_run_summary.py
@@ -67,7 +67,7 @@ def test_run_summary(tmp_path, monkeypatch):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/unit/test_confirmation_independent.py
+++ b/tests/unit/test_confirmation_independent.py
@@ -72,7 +72,7 @@ def test_independent_confirmation_statuses(monkeypatch, tmp_path):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=False,
         read_only=False,

--- a/tests/unit/test_confirmation_modes.py
+++ b/tests/unit/test_confirmation_modes.py
@@ -58,7 +58,7 @@ def test_per_account_prompts_once_per_account(monkeypatch, tmp_path):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -89,7 +89,7 @@ def test_global_prompt_once_and_aborts(monkeypatch, tmp_path, capsys):
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=False,
         yes=False,
         read_only=False,

--- a/tests/unit/test_parallel_accounts_flag.py
+++ b/tests/unit/test_parallel_accounts_flag.py
@@ -64,7 +64,7 @@ def test_parallel_accounts_flag_overrides_config(
 
     args = Namespace(
         config="config/settings.ini",
-        csv="data/portfolios.csv",
+        csv=str(Path("..") / "data" / "portfolios.csv"),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/unit/test_rebalance_csv_path_resolution.py
+++ b/tests/unit/test_rebalance_csv_path_resolution.py
@@ -1,0 +1,79 @@
+"""Tests for resolving CSV paths relative to the config file."""
+
+import asyncio
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import src.rebalance as rebalance
+from src.io.config_loader import ConfirmMode, load_config as real_load_config
+from tests.unit.test_config_loader import VALID_CONFIG
+
+
+def test_csv_path_resolved_relative_to_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured: dict[str, Path] = {}
+
+    async def fake_load_portfolios(path_map, *, host, port, client_id):  # noqa: ARG001
+        captured.update(path_map)
+        return {aid: {} for aid in path_map}
+
+    async def fake_plan_account(account_id, portfolios, cfg, ts_dt, **kwargs):  # noqa: ARG001
+        return {
+            "account_id": account_id,
+            "drifts": [],
+            "trades": [],
+            "prices": {},
+            "current": {},
+            "targets": {},
+            "net_liq": 0.0,
+            "pre_gross_exposure": 0.0,
+            "pre_leverage": 0.0,
+            "post_leverage": 0.0,
+            "planned_orders": 0,
+            "buy_usd": 0.0,
+            "sell_usd": 0.0,
+        }
+
+    async def fake_confirm_global(*args, **kwargs):  # noqa: ANN001,ARG001
+        return []
+
+    monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
+    monkeypatch.setattr(rebalance, "plan_account", fake_plan_account)
+    monkeypatch.setattr(rebalance, "confirm_global", fake_confirm_global)
+    monkeypatch.setattr(rebalance, "setup_logging", lambda *a, **k: None)
+
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    cfg_path = cfg_dir / "settings.ini"
+    cfg_path.write_text(VALID_CONFIG)
+    csv_path = tmp_path / "default.csv"
+    csv_path.write_text("")
+
+    def fake_load_config(_path):  # noqa: ARG001
+        cfg = real_load_config(cfg_path)
+        cfg.accounts.pacing_sec = 0.0
+        cfg.accounts.confirm_mode = ConfirmMode.GLOBAL
+        cfg.io.report_dir = str(tmp_path)
+        return cfg
+
+    monkeypatch.setattr(rebalance, "load_config", fake_load_config)
+
+    args = Namespace(
+        config=str(cfg_path),
+        csv="../default.csv",
+        dry_run=True,
+        yes=True,
+        read_only=False,
+        confirm_mode=None,
+        parallel_accounts=False,
+    )
+
+    asyncio.run(rebalance._run(args))
+
+    expected = csv_path.resolve()
+    assert captured == {"ACC1": expected, "ACC2": expected}
+


### PR DESCRIPTION
## Summary
- Resolve configuration path and base directory after loading config
- Map portfolio CSV files relative to config directory and ensure absolute paths
- Cover CSV path resolution with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf4b6d6f88320aaed8fa5348da775