### PR TITLE
Preserve original planned order count

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -50,6 +50,7 @@ async def confirm_per_account(
     post_leverage = plan["post_leverage"]
     table = plan["table"]
     planned_orders = plan["planned_orders"]
+    planned_orders_initial = planned_orders
     buy_usd = plan["buy_usd"]
     sell_usd = plan["sell_usd"]
 
@@ -293,7 +294,6 @@ async def confirm_per_account(
             sell_usd += value
     trades = all_trades
     results = all_results
-    planned_orders = len(trades)
     post_path = write_post_trade_report(
         Path(cfg.io.report_dir),
         ts_dt,
@@ -320,7 +320,7 @@ async def confirm_per_account(
         {
             "timestamp_run": ts_dt.isoformat(),
             "account_id": account_id,
-            "planned_orders": planned_orders,
+            "planned_orders": planned_orders_initial,
             "submitted": len(trades),
             "filled": filled,
             "rejected": rejected,

--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -260,3 +260,135 @@ def test_confirm_per_account_reports_totals_for_same_symbol_buys_and_sells(tmp_p
     summary = appended[0]
     assert summary["buy_usd"] == 10.0
     assert summary["sell_usd"] == 11.0
+
+
+def test_confirm_per_account_summary_reports_planned_and_executed(tmp_path):
+    cfg = AppConfig(
+        ibkr=IBKR(host="localhost", port=4001, client_id=1, read_only=False),
+        models=Models(smurf=0.5, badass=0.3, gltr=0.2),
+        rebalance=Rebalance(
+            trigger_mode="band",
+            per_holding_band_bps=0,
+            portfolio_total_band_bps=0,
+            min_order_usd=10,
+            cash_buffer_type="abs",
+            cash_buffer_pct=None,
+            cash_buffer_abs=0.0,
+            allow_fractional=False,
+            max_leverage=1.0,
+            maintenance_buffer_pct=0.0,
+            trading_hours="rth",
+            max_passes=2,
+        ),
+        pricing=Pricing(price_source="last", fallback_to_snapshot=False),
+        execution=Execution(
+            order_type="market",
+            algo_preference="adaptive",
+            fallback_plain_market=False,
+            commission_report_timeout=0.0,
+            wait_before_fallback=0.0,
+            batch_orders=False,
+        ),
+        io=IO(report_dir=str(tmp_path), log_level="INFO"),
+        accounts=Accounts(ids=["ACC1"], confirm_mode=ConfirmMode.PER_ACCOUNT),
+        account_overrides={},
+    )
+
+    plan = {
+        "account_id": "ACC1",
+        "trades": [SizedTrade("XYZ", "BUY", 1, 10.0)],
+        "drifts": [],
+        "prices": {"XYZ": 10.0},
+        "current": {"CASH": 1000.0},
+        "targets": {},
+        "net_liq": 1000.0,
+        "pre_gross_exposure": 0.0,
+        "pre_leverage": 0.0,
+        "post_leverage": 0.0,
+        "table": "",
+        "planned_orders": 1,
+        "buy_usd": 10.0,
+        "sell_usd": 0.0,
+    }
+
+    args = SimpleNamespace(dry_run=False, read_only=False, yes=True)
+
+    appended = []
+
+    async def submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
+        results = []
+        for t in trades:
+            price = 10.0 if t.action == "BUY" else 11.0
+            results.append(
+                {
+                    "symbol": t.symbol,
+                    "status": "Filled",
+                    "fill_qty": t.quantity,
+                    "fill_price": price,
+                }
+            )
+        return results
+
+    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+        return ["dummy"]
+
+    def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
+        return drifts
+
+    calls = {"n": 0}
+
+    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+        if calls["n"] == 0:
+            calls["n"] += 1
+            return [SizedTrade("XYZ", "SELL", 1, 11.0)], 0.0, 0.0
+        return [], 0.0, 0.0
+
+    def append_run_summary(path, ts_dt, row):  # noqa: ARG001
+        appended.append(row)
+
+    def write_post_trade_report(
+        path,
+        ts_dt,
+        account_id,
+        drifts,
+        trades,
+        results,
+        prices_before,
+        net_liq,
+        pre_gross_exposure,
+        pre_leverage,
+        post_gross_exposure_actual,
+        post_leverage_actual,
+        cfg,
+    ):  # noqa: ARG001
+        return path / "report.json"
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    ts_dt = datetime.utcnow()
+    asyncio.run(
+        confirm_per_account(
+            plan,
+            args,
+            cfg,
+            ts_dt,
+            client_factory=DummyClient,
+            submit_batch=submit_batch,
+            append_run_summary=append_run_summary,
+            write_post_trade_report=write_post_trade_report,
+            compute_drift=compute_drift,
+            prioritize_by_drift=prioritize_by_drift,
+            size_orders=size_orders,
+        )
+    )
+
+    summary = appended[0]
+    assert summary["planned_orders"] == 1
+    assert summary["submitted"] == 2
+    assert summary["filled"] == 2
+    assert summary["rejected"] == 0


### PR DESCRIPTION
## Summary
- keep the original planned order tally before execution
- ensure summary reporting uses the initial plan count while tracking executed orders separately
- add unit test for planned vs executed order totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf837799083208a1dab9040639870