### PR TITLE
Support configurable portfolio paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ids = DU111111, DU222222
 confirm_mode = per_account        ; per_account | global
 pacing_sec = 1                    ; seconds to pause between accounts
 parallel = false                  ; true processes accounts concurrently
+path = data/portfolios.csv        ; portfolio CSV (relative to settings.ini)
 ```
 
 The same `portfolios.csv` applies to all listed accounts. `confirm_mode`
@@ -59,6 +60,9 @@ be enabled at runtime via `--parallel-accounts`. When running with
 `confirm_mode = per_account` and interactive prompts (i.e., without `--yes`),
 plans are computed concurrently but confirmations are serialized per account to
 avoid overlapping prompts.
+
+Paths in `[accounts]` and `[portfolio:<ID>]` sections are resolved relative to
+the directory containing `settings.ini`.
 
 Example forcing a global prompt:
 

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -19,7 +19,7 @@ confirm_mode = per_account
 pacing_sec = 5
 ; Process accounts concurrently when true; confirmations serialize only when prompts are shown (i.e., without --yes)
 parallel = false
-; portfolio CSV 
+; portfolio CSV (relative to this file)
 path = portfolios.csv
 
 ; Example per-account overrides
@@ -31,6 +31,7 @@ path = portfolios.csv
 
 ; Optional per-account portfolio CSV override
 [portfolio:DU111111]
+; relative to this file
 path = portfolios_DU111111.csv
 
 [models]

--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -71,8 +71,12 @@ async def confirm_per_account(
         else:
             append_run_summary(Path(cfg.io.report_dir), ts_dt, row)
 
-    def _build_lookup(res_list: list[Mapping[str, Any]]) -> dict[tuple[str | None, str | None], deque[Mapping[str, Any]]]:
-        lookup: dict[tuple[str | None, str | None], deque[Mapping[str, Any]]] = defaultdict(deque)
+    def _build_lookup(
+        res_list: list[Mapping[str, Any]],
+    ) -> dict[tuple[str | None, str | None], deque[Mapping[str, Any]]]:
+        lookup: dict[tuple[str | None, str | None], deque[Mapping[str, Any]]] = (
+            defaultdict(deque)
+        )
         for r in res_list:
             sym = r.get("symbol")
             if sym is None:
@@ -94,7 +98,9 @@ async def confirm_per_account(
             price_any = res.get("fill_price")
             if price_any is None:
                 price_any = res.get("avg_fill_price", 0.0)
-            value = float(qty_any) * float(price_any)
+            qty = float(qty_any or 0.0)
+            price = float(price_any or 0.0)
+            value = qty * price
             if t.action == "BUY":
                 buy_total += value
             else:

--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -110,6 +110,7 @@ class Accounts:
     confirm_mode: ConfirmMode
     pacing_sec: float = 0.0
     parallel: bool = False
+    path: Path | None = None
 
 
 @dataclass
@@ -125,6 +126,7 @@ class AppConfig:
     accounts: Accounts
     account_overrides: Dict[str, AccountOverride] = field(default_factory=dict)
     portfolio_paths: Dict[str, Path] = field(default_factory=dict)
+    accounts_path: Path | None = None
 
 
 TOLERANCE = 0.001
@@ -282,11 +284,20 @@ def load_config(path: Path) -> AppConfig:
         parallel = cp.getboolean("accounts", "parallel", fallback=False)
     except ValueError as exc:
         raise ConfigError("[accounts] parallel must be a boolean") from exc
+    raw_accounts_path = cp.get("accounts", "path", fallback=None)
+    accounts_path = None
+    if raw_accounts_path:
+        accounts_path = (base_dir / Path(raw_accounts_path)).resolve()
+        if not accounts_path.is_file():
+            raise ConfigError(
+                f"[accounts] path is missing or not a regular file: {accounts_path}"
+            )
     accounts = Accounts(
         ids=ids,
         confirm_mode=confirm_mode,
         pacing_sec=pacing_sec,
         parallel=parallel,
+        path=accounts_path,
     )
 
     ibkr = IBKR(
@@ -460,6 +471,7 @@ def load_config(path: Path) -> AppConfig:
         accounts=accounts,
         account_overrides=account_overrides,
         portfolio_paths=portfolio_paths,
+        accounts_path=accounts_path,
     )
 
 

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -48,7 +48,7 @@ async def _print_err(msg: str, lock: asyncio.Lock | None) -> None:
 
 async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
     cfg_path = Path(args.config)
-    csv_path = Path(args.csv)
+    csv_arg = args.csv
     print(f"[blue]Loading configuration from {cfg_path}[/blue]")
     cfg: AppConfig = load_config(cfg_path)
     cfg_path = cfg_path.resolve()
@@ -63,6 +63,14 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
     setup_logging(Path(cfg.io.report_dir), cfg.io.log_level, timestamp)
     logging.info("Loaded configuration from %s", cfg_path)
 
+    if csv_arg is not None:
+        csv_path = Path(csv_arg)
+    else:
+        accounts_path = getattr(cfg.accounts, "path", None)
+        if accounts_path is not None:
+            csv_path = accounts_path
+        else:
+            csv_path = Path("data/portfolios.csv")
     if not csv_path.is_absolute():
         csv_path = (cfg_dir / csv_path).resolve()
     portfolio_paths: dict[str, Path] = getattr(cfg, "portfolio_paths", {})
@@ -355,8 +363,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--csv",
-        default="data/portfolios.csv",
-        help="Path to portfolio CSV",
+        default=None,
+        help="Path to portfolio CSV (defaults to [accounts] path or data/portfolios.csv)",
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -156,6 +156,32 @@ def test_portfolio_paths_resolve_from_config_dir(
     assert cfg.portfolio_paths == {"ACC1": (cfg_dir / portfolio_rel).resolve()}
 
 
+def test_accounts_path_resolves_from_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    rel = Path("data/foo.csv")
+    (cfg_dir / rel).parent.mkdir(parents=True)
+    (cfg_dir / rel).write_text("")
+    cfg_path = cfg_dir / "settings.ini"
+    cfg_content = VALID_CONFIG.replace(
+        "[accounts]\nids = ACC1, ACC2\n",
+        f"[accounts]\nids = ACC1, ACC2\npath = {rel.as_posix()}\n",
+    )
+    cfg_path.write_text(cfg_content)
+
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+
+    cfg = load_config(cfg_path)
+
+    expected = (cfg_dir / rel).resolve()
+    assert cfg.accounts.path == expected
+    assert cfg.accounts_path == expected
+
+
 def test_portfolio_path_missing(tmp_path: Path) -> None:
     cfg_path = tmp_path / "settings.ini"
     cfg_path.write_text(VALID_CONFIG + "\n[portfolio: acc1]\npath = missing.csv\n")

--- a/tests/unit/test_rebalance_csv_path_resolution.py
+++ b/tests/unit/test_rebalance_csv_path_resolution.py
@@ -81,3 +81,75 @@ def test_csv_path_resolved_relative_to_config(
 
     expected = csv_path.resolve()
     assert captured == {"ACC1": expected, "ACC2": expected}
+
+
+def test_default_csv_path_from_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Path] = {}
+
+    async def fake_load_portfolios(path_map, *, host, port, client_id):  # noqa: ARG001
+        captured.update(path_map)
+        return {aid: {} for aid in path_map}
+
+    async def fake_plan_account(
+        account_id, portfolios, cfg, ts_dt, **kwargs
+    ):  # noqa: ANN001,ARG001
+        return {
+            "account_id": account_id,
+            "drifts": [],
+            "trades": [],
+            "prices": {},
+            "current": {},
+            "targets": {},
+            "net_liq": 0.0,
+            "pre_gross_exposure": 0.0,
+            "pre_leverage": 0.0,
+            "post_leverage": 0.0,
+            "planned_orders": 0,
+            "buy_usd": 0.0,
+            "sell_usd": 0.0,
+        }
+
+    async def fake_confirm_global(*args, **kwargs):  # noqa: ANN001,ARG001
+        return []
+
+    monkeypatch.setattr(rebalance, "load_portfolios", fake_load_portfolios)
+    monkeypatch.setattr(rebalance, "plan_account", fake_plan_account)
+    monkeypatch.setattr(rebalance, "confirm_global", fake_confirm_global)
+    monkeypatch.setattr(rebalance, "setup_logging", lambda *a, **k: None)
+
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    cfg_path = cfg_dir / "settings.ini"
+    cfg_content = VALID_CONFIG.replace(
+        "[accounts]\nids = ACC1, ACC2\n",
+        "[accounts]\nids = ACC1, ACC2\npath = default.csv\n",
+    )
+    cfg_path.write_text(cfg_content)
+    csv_path = cfg_dir / "default.csv"
+    csv_path.write_text("")
+
+    def fake_load_config(_path):  # noqa: ARG001
+        cfg = real_load_config(cfg_path)
+        cfg.accounts.pacing_sec = 0.0
+        cfg.accounts.confirm_mode = ConfirmMode.GLOBAL
+        cfg.io.report_dir = str(tmp_path)
+        return cfg
+
+    monkeypatch.setattr(rebalance, "load_config", fake_load_config)
+
+    args = Namespace(
+        config=str(cfg_path),
+        csv=None,
+        dry_run=True,
+        yes=True,
+        read_only=False,
+        confirm_mode=None,
+        parallel_accounts=False,
+    )
+
+    asyncio.run(rebalance._run(args))
+
+    expected = csv_path.resolve()
+    assert captured == {"ACC1": expected, "ACC2": expected}


### PR DESCRIPTION
## Summary
- allow configuration of a global portfolio CSV path via `[accounts] path`
- resolve portfolio paths relative to `settings.ini` across rebalance and validation
- document path resolution rules and cover them with new tests

## Testing
- `pre-commit run --files README.md config/settings.ini src/io/config_loader.py src/io/validate_portfolios.py src/rebalance.py src/core/confirmation.py tests/unit/test_config_loader.py tests/unit/test_rebalance_csv_path_resolution.py tests/unit/test_validate_portfolios_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0014a60c8320a26415c894e56fbc