### PR TITLE
docs: update portfolio CSV paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ pytest -q -m "not integration"
 
 ### Customize sample files
 
-The repository includes example `config/settings.ini` and `data/portfolios.csv`.
+The repository includes example `config/settings.ini` and `config/portfolios.csv`.
 Make copies of these files outside version control and edit them with your own
 IBKR host and target weights. Account IDs are listed under the `[accounts]`
 section:
 
 ```bash
 cp config/settings.ini my_settings.ini
-cp data/portfolios.csv my_portfolios.csv
+cp config/portfolios.csv my_portfolios.csv
 ```
 
 Blank cells in the CSV represent 0% allocations. Use the copied files via
@@ -44,7 +44,7 @@ ids = DU111111, DU222222
 confirm_mode = per_account        ; per_account | global
 pacing_sec = 1                    ; seconds to pause between accounts
 parallel = false                  ; true processes accounts concurrently
-path = data/portfolios.csv        ; portfolio CSV (relative to settings.ini)
+path = portfolios.csv        ; portfolio CSV (relative to settings.ini)
 ```
 
 The same `portfolios.csv` applies to all listed accounts. `confirm_mode`
@@ -67,7 +67,7 @@ the directory containing `settings.ini`.
 Example forcing a global prompt:
 
 ```bash
-python src/rebalance.py --dry-run --confirm-mode global --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --confirm-mode global --config config/settings.ini --csv config/portfolios.csv
 ```
 
 Orders sent to Interactive Brokers are tagged with the respective account code
@@ -105,10 +105,10 @@ resolved relative to the directory containing `settings.ini`:
 
 ```ini
 [portfolio:DU111111]
-path = data/portfolios_DU111111.csv  # relative to settings.ini
+path = portfolios_DU111111.csv  # relative to settings.ini
 
 [portfolio:DU222222]
-path = data/portfolios_DU222222.csv
+path = portfolios_DU222222.csv
 ```
 
 Accounts without an override use the global CSV. `validate_portfolios --all`
@@ -116,7 +116,7 @@ needs a valid global CSV unless every account has an override. Example run
 mixing global and per-account files:
 
 ```bash
-python src/rebalance.py --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --config config/settings.ini --csv config/portfolios.csv
 ```
 
 ## Usage
@@ -130,14 +130,14 @@ python -m src.io.validate_config config/settings.ini
 Validate a single CSV (or all configured per-account files when each account
 has one):
 ```bash
-python -m src.io.validate_portfolios --config config/settings.ini data/portfolios.csv
+python -m src.io.validate_portfolios --config config/settings.ini config/portfolios.csv
 
 # if every account has a dedicated portfolio CSV, omit the global file
 python -m src.io.validate_portfolios --config config/settings.ini
 ```
 Validate all portfolio files including account-specific overrides:
 ```bash
-python -m src.io.validate_portfolios --config config/settings.ini --all data/portfolios.csv
+python -m src.io.validate_portfolios --config config/settings.ini --all config/portfolios.csv
 ```
 An active IBKR session (TWS or IB Gateway) must be running so the tool can
 verify ticker symbols.
@@ -171,7 +171,7 @@ The main rebalancer prints a batch summary preview before submitting trades.
 Launch IB Gateway or Trader Workstation, then run:
 
 ```bash
-python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --config config/settings.ini --csv config/portfolios.csv
 ```
 Displays the batch summary and exits without placing orders.
 
@@ -182,7 +182,7 @@ account in sequence. Run the same command to simulate the batch, or add
 remain serialized without `--yes` so prompts appear one at a time:
 
 ```bash
-python src/rebalance.py --dry-run --parallel-accounts --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --parallel-accounts --config config/settings.ini --csv config/portfolios.csv
 ```
 
 Each account prints its own table. Example output:
@@ -226,19 +226,19 @@ processed.
 
 ### Interactive execution
 ```bash
-python src/rebalance.py --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --config config/settings.ini --csv config/portfolios.csv
 ```
 Shows the preview and waits for `y` before trading.
 
 ### Non-interactive execution
 ```bash
-python src/rebalance.py --yes --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --yes --config config/settings.ini --csv config/portfolios.csv
 ```
 Skips the confirmation prompt and submits orders immediately.
 
 ### Read-only guard
 ```bash
-python src/rebalance.py --read-only --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --read-only --config config/settings.ini --csv config/portfolios.csv
 ```
 Forces preview-only mode even if `--yes` is used.
 

--- a/dev-plan/101.md
+++ b/dev-plan/101.md
@@ -9,7 +9,7 @@ cd IB_Trade
 conda create -n ibkr-rebal python=3.10 -y
 conda activate ibkr-rebal
 pip install -r requirements.txt -r requirements-dev.txt
-python -m src.rebalance --config config\settings.ini --csv data\portfolios.csv
+python -m src.rebalance --config config\settings.ini --csv config\portfolios.csv
 ```
 ## 0) One‑Time Setup (do this once)
 
@@ -123,13 +123,13 @@ PY
 ---
 
 ### Phase B2 — CSV parser & portfolio checks
-**Goal:** The app reads `data/portfolios.csv` and checks for mistakes.
+**Goal:** The app reads `config/portfolios.csv` and checks for mistakes.
 
 **Do this (temporary placeholder test):**
 ```bat
 python - <<"PY"
 from pathlib import Path
-p = Path("data/portfolios.csv")
+p = Path("config/portfolios.csv")
 print("CSV exists:", p.exists())
 print("First 3 lines:")
 print("\n".join(p.read_text().splitlines()[:3]))
@@ -138,7 +138,7 @@ PY
 
 > When the real code exists, run:
 > ```bat
-> python -m src.io.validate_portfolios --config config\settings.ini data\portfolios.csv
+> python -m src.io.validate_portfolios --config config\settings.ini config\portfolios.csv
 > ```
 
 **What success looks like:**
@@ -186,7 +186,7 @@ PY
 ```
 > When the real code exists, you might run:
 > ```bat
-> python -m src.core.targets --config config\settings.ini --csv data\portfolios.csv
+> python -m src.core.targets --config config\settings.ini --csv config\portfolios.csv
 > ```
 > Expect a table like: `SPY 25.0%`, `IAU 7.0%`, ... and totals ≈ 100%.
 
@@ -208,7 +208,7 @@ pytest tests/unit/test_drift.py::test_per_holding_mode_triggers_symbols_and_skip
 pytest tests/unit/test_drift.py::test_total_drift_mode_selects_largest_until_band -q
 pytest tests/unit/test_drift.py::test_prioritize_by_drift_filters_and_sorts -q
 pytest tests/unit/test_prioritize.py::test_prioritize_filters_and_sorts_by_abs_drift_usd -q
-python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --config config/settings.ini --csv config/portfolios.csv
 
 ```
 These commands will:
@@ -233,7 +233,7 @@ These commands will:
 **Do this (placeholder):**
 ```bat
 pytest -q tests/unit/test_sizing.py
-python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --config config/settings.ini --csv config/portfolios.csv
 ```
 > Later, expect whole‑share numbers (unless fractional is allowed) and a note that leverage stays under the max.
 
@@ -253,7 +253,7 @@ python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfo
 
 **Do this:**
 ```bat
-python src\rebalance.py --dry-run --config config\settings.ini --csv data\portfolios.csv
+python src\rebalance.py --dry-run --config config\settings.ini --csv config\portfolios.csv
 ```
 
 **What success looks like:**
@@ -271,7 +271,7 @@ python src\rebalance.py --dry-run --config config\settings.ini --csv data\portfo
 **Goal:** After you press **Y**, the app sends **market orders** (adaptive/midprice if possible; else plain market).
 
 **Do this:**
-- Run `python src\rebalance.py --confirm --config config\settings.ini --csv data\portfolios.csv`.
+- Run `python src\rebalance.py --confirm --config config\settings.ini --csv config\portfolios.csv`.
 - When it asks `Proceed? [y/N]:`, type **y** and press **Enter**.
 - Watch the console for **"Submitting batch..."** and **"Done."**
 - Switch to **TWS → Orders** and check that each symbol shows status **"Filled"** or **"Submitted."**

--- a/dev-plan/101_addon.md
+++ b/dev-plan/101_addon.md
@@ -33,7 +33,7 @@ conda activate ibkr-rebal
 cd path\to\IB_Simple
 pre-commit run --all-files
 pytest -q
-python -m src.rebalance --dry-run --config config/settings.ini --csv data/portfolios.csv
+python -m src.rebalance --dry-run --config config/settings.ini --csv config/portfolios.csv
 ```
 **What success looks like:**
 - Pre-commit and pytest pass.
@@ -52,7 +52,7 @@ conda activate ibkr-rebal
 cd path\to\IB_Simple
 pre-commit run --all-files
 pytest -q
-python -m src.rebalance --config config/settings.ini --csv data/portfolios.csv
+python -m src.rebalance --config config/settings.ini --csv config/portfolios.csv
 ```
 When prompted for each account, type `y` and press Enter.
 After it finishes:
@@ -77,7 +77,7 @@ conda activate ibkr-rebal
 cd path\to\IB_Simple
 pre-commit run --all-files
 pytest -q
-python -m src.rebalance --dry-run --config config/settings.ini --csv data/portfolios.csv
+python -m src.rebalance --dry-run --config config/settings.ini --csv config/portfolios.csv
 ```
 Try again with one fake account ID to see friendly errors.
 

--- a/dev-plan/plan.md
+++ b/dev-plan/plan.md
@@ -24,7 +24,7 @@
 **Deliverables**
 - `README.md` with quickstart
 - Base repo structure:
-  - `src/` (code), `tests/` (pytest), `reports/` (output), `config/` (sample `settings.ini`), `data/` (sample `portfolios.csv`)
+  - `src/` (code), `tests/` (pytest), `reports/` (output), `config/` (sample `settings.ini` and `portfolios.csv`)
 - `.editorconfig`, `.gitignore`, `requirements.txt`, `requirements-dev.txt` / `pyproject.toml`
 - `pre-commit` hooks (black, isort, ruff/flake8)
 
@@ -101,7 +101,7 @@
 - [ ] Unknown ETF symbol aborts
 
 **Acceptance**
-- CLI `python -m src.io.validate_portfolios data/portfolios.csv` prints OK or detailed errors
+- CLI `python -m src.io.validate_portfolios config/portfolios.csv` prints OK or detailed errors
 
 ---
 
@@ -354,14 +354,14 @@ jobs:
 
 ## 7) Operational Runbook (MVP)
 
-1) Edit `config/settings.ini` and `data/portfolios.csv`  
+1) Edit `config/settings.ini` and `config/portfolios.csv`  
 2) Dry-run:
 ```bash
-python rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python rebalance.py --dry-run --config config/settings.ini --csv config/portfolios.csv
 ```
 3) Live (paper):
 ```bash
-python rebalance.py --confirm --config config/settings.ini --csv data/portfolios.csv
+python rebalance.py --confirm --config config/settings.ini --csv config/portfolios.csv
 ```
 4) Inspect `reports/rebalance_*.csv` and logs
 

--- a/dev-plan/workflow.md
+++ b/dev-plan/workflow.md
@@ -33,10 +33,9 @@ ibkr-rebalancer/
 ├─ tests/
 │  ├─ unit/
 │  └─ integration/
-├─ data/
-│  └─ portfolios.csv    # sample
 ├─ config/
-│  └─ settings.ini      # sample
+│  ├─ settings.ini      # sample
+│  └─ portfolios.csv    # sample
 ├─ reports/             # output (gitignored)
 ├─ README.md
 ├─ requirements.txt, requirements-dev.txt (or pyproject.toml)
@@ -164,7 +163,7 @@ report_dir = reports
 log_level = INFO
 ```
 
-`data/portfolios.csv` (example only)
+`config/portfolios.csv` (example only)
 ```
 ETF,SMURF,BADASS,GLTR
 BLOK,,0%,
@@ -280,7 +279,7 @@ def load_config(path: str):
 - Happy path; CASH positive; CASH negative; malformed `%` raises error.
 
 **Acceptance**
-- `python -m src.io.portfolio_csv data/portfolios.csv` prints “OK” or clear errors
+- `python -m src.io.portfolio_csv config/portfolios.csv` prints “OK” or clear errors
 
 ---
 
@@ -442,13 +441,13 @@ pre-commit run --all-files
 pytest -q -m "not integration"
 
 # Validate portfolio CSV
-python -m src.io.validate_portfolios data/portfolios.csv
+python -m src.io.validate_portfolios config/portfolios.csv
 
 # Dry-run preview
-python src/rebalance.py --dry-run --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --dry-run --config config/settings.ini --csv config/portfolios.csv
 
 # Live (paper) with confirmation
-python src/rebalance.py --confirm --config config/settings.ini --csv data/portfolios.csv
+python src/rebalance.py --confirm --config config/settings.ini --csv config/portfolios.csv
 
 # Show latest report
 powershell -Command "Get-ChildItem reports | Sort-Object LastWriteTime -Descending | Select-Object -First 1"


### PR DESCRIPTION
## Summary
- reference sample portfolios.csv next to settings.ini
- fix accounts and per-account examples
- update dev-plan docs to match new paths

## Testing
- `pre-commit run --files README.md dev-plan/101.md dev-plan/101_addon.md dev-plan/plan.md dev-plan/workflow.md`

------
https://chatgpt.com/codex/tasks/task_e_68bb06b4a16c8320acf1ac3f0a597404