### PR TITLE
Use config portfolios CSV in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+import pytest
+
+@pytest.fixture
+def portfolios_csv_path() -> Path:
+    """Path to the default portfolios CSV used in tests."""
+    return Path(__file__).resolve().parent.parent / "config" / "portfolios.csv"

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -97,7 +97,7 @@ async def stub_confirm_per_account(
     )
 
 
-def test_parallel_accounts(monkeypatch, tmp_path):
+def test_parallel_accounts(monkeypatch, tmp_path, portfolios_csv_path):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
     monkeypatch.setattr(rebalance, "plan_account", stub_plan_account)
     monkeypatch.setattr(rebalance, "confirm_per_account", stub_confirm_per_account)
@@ -117,7 +117,7 @@ def test_parallel_accounts(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -139,7 +139,7 @@ def test_parallel_accounts(monkeypatch, tmp_path):
     assert [row["account_id"] for row in rows] == ["DU111111", "DU222222"]
 
 
-def test_parallel_confirmation_overlap(monkeypatch, tmp_path):
+def test_parallel_confirmation_overlap(monkeypatch, tmp_path, portfolios_csv_path):
     """Confirmations run concurrently when confirmation is auto-approved."""
     confirm_starts.clear()
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
@@ -161,7 +161,7 @@ def test_parallel_confirmation_overlap(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=True,
         read_only=False,
@@ -174,7 +174,7 @@ def test_parallel_confirmation_overlap(monkeypatch, tmp_path):
     assert abs(confirm_starts[1] - confirm_starts[0]) < 0.05
 
 
-def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path):
+def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path, portfolios_csv_path):
     """Exceptions during serialized confirmation print atomically."""
 
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
@@ -219,7 +219,7 @@ def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -236,7 +236,7 @@ def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path):
         assert not ("noise" in line and "boom" in line)
 
 
-def test_serialized_planner_output(monkeypatch, capsys, tmp_path):
+def test_serialized_planner_output(monkeypatch, capsys, tmp_path, portfolios_csv_path):
     """Planner output prints atomically under parallel planning."""
 
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
@@ -297,7 +297,7 @@ def test_serialized_planner_output(monkeypatch, capsys, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=True,
         read_only=False,

--- a/tests/integration/test_parallel_pacing.py
+++ b/tests/integration/test_parallel_pacing.py
@@ -92,7 +92,7 @@ async def stub_confirm_per_account(
     )
 
 
-def test_parallel_pacing(monkeypatch, tmp_path):
+def test_parallel_pacing(monkeypatch, tmp_path, portfolios_csv_path):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)
     monkeypatch.setattr(rebalance, "plan_account", stub_plan_account)
     monkeypatch.setattr(rebalance, "confirm_per_account", stub_confirm_per_account)
@@ -112,7 +112,7 @@ def test_parallel_pacing(monkeypatch, tmp_path):
 
     args = SimpleNamespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -54,7 +54,9 @@ async def fake_validate_symbols(symbols, host, port, client_id):  # noqa: ARG001
 
 
 def test_prompt_default(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    portfolios_csv_path: Path,
 ) -> None:
     """Default execution prompts and aborts when the user declines."""
 
@@ -70,7 +72,7 @@ def test_prompt_default(
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -84,7 +86,9 @@ def test_prompt_default(
 
 
 def test_yes_skips_prompt(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    portfolios_csv_path: Path,
 ) -> None:
     """The --yes flag suppresses the prompt and proceeds."""
 
@@ -114,7 +118,7 @@ def test_yes_skips_prompt(
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=True,
         read_only=False,
@@ -128,7 +132,9 @@ def test_yes_skips_prompt(
 
 
 def test_prompt_global(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    portfolios_csv_path: Path,
 ) -> None:
     """Global confirmation prompts once for all accounts."""
 
@@ -147,7 +153,7 @@ def test_prompt_global(
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -162,7 +168,9 @@ def test_prompt_global(
 
 
 def test_yes_skips_prompt_global(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    portfolios_csv_path: Path,
 ) -> None:
     """--yes skips the global confirmation prompt."""
 
@@ -192,7 +200,7 @@ def test_yes_skips_prompt_global(
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=True,
         read_only=False,

--- a/tests/integration/test_rebalance_dry_run.py
+++ b/tests/integration/test_rebalance_dry_run.py
@@ -51,14 +51,14 @@ async def fake_validate_symbols(symbols, host, port, client_id):  # noqa: ARG001
     return None
 
 
-def test_rebalance_dry_run(monkeypatch, capsys):
+def test_rebalance_dry_run(monkeypatch, capsys, portfolios_csv_path):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,
@@ -73,7 +73,7 @@ def test_rebalance_dry_run(monkeypatch, capsys):
     assert "Proceed?" not in captured
 
 
-def test_rebalance_multiple_accounts_failure(monkeypatch, capsys):
+def test_rebalance_multiple_accounts_failure(monkeypatch, capsys, portfolios_csv_path):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
@@ -89,7 +89,7 @@ def test_rebalance_multiple_accounts_failure(monkeypatch, capsys):
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/integration/test_run_summary.py
+++ b/tests/integration/test_run_summary.py
@@ -49,7 +49,7 @@ async def fake_validate_symbols(symbols, host, port, client_id):  # noqa: ARG001
     return None
 
 
-def test_run_summary(tmp_path, monkeypatch):
+def test_run_summary(tmp_path, monkeypatch, portfolios_csv_path):
     monkeypatch.setattr(rebalance, "IBKRClient", DummyIBKRClient)
     monkeypatch.setattr(rebalance, "_fetch_price", fake_fetch_price)
     monkeypatch.setattr(portfolio_csv, "validate_symbols", fake_validate_symbols)
@@ -67,7 +67,7 @@ def test_run_summary(tmp_path, monkeypatch):
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/unit/test_confirmation_independent.py
+++ b/tests/unit/test_confirmation_independent.py
@@ -58,7 +58,7 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, tmp_path, records, executed):
     monkeypatch.setattr(rebalance.asyncio, "sleep", fake_sleep)
 
 
-def test_independent_confirmation_statuses(monkeypatch, tmp_path):
+def test_independent_confirmation_statuses(monkeypatch, tmp_path, portfolios_csv_path: Path):
     records: list[dict[str, str]] = []
     executed: list[str] = []
     _patch_common(monkeypatch, tmp_path, records, executed)
@@ -72,7 +72,7 @@ def test_independent_confirmation_statuses(monkeypatch, tmp_path):
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=False,
         read_only=False,

--- a/tests/unit/test_confirmation_modes.py
+++ b/tests/unit/test_confirmation_modes.py
@@ -46,7 +46,9 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setattr(rebalance, "setup_logging", lambda *a, **k: None)
 
 
-def test_per_account_prompts_once_per_account(monkeypatch, tmp_path):
+def test_per_account_prompts_once_per_account(
+    monkeypatch, tmp_path, portfolios_csv_path: Path
+):
     _patch_common(monkeypatch, tmp_path)
     prompts: list[str] = []
 
@@ -58,7 +60,7 @@ def test_per_account_prompts_once_per_account(monkeypatch, tmp_path):
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=False,
         read_only=False,
@@ -69,7 +71,7 @@ def test_per_account_prompts_once_per_account(monkeypatch, tmp_path):
     assert prompts == ["Proceed? [y/N]: ", "Proceed? [y/N]: "]
 
 
-def test_global_prompt_once_and_aborts(monkeypatch, tmp_path, capsys):
+def test_global_prompt_once_and_aborts(monkeypatch, tmp_path, capsys, portfolios_csv_path: Path):
     records: list[dict[str, str]] = []
 
     def fake_append(report_dir, ts, row):  # noqa: ARG001
@@ -89,7 +91,7 @@ def test_global_prompt_once_and_aborts(monkeypatch, tmp_path, capsys):
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=False,
         yes=False,
         read_only=False,

--- a/tests/unit/test_parallel_accounts_flag.py
+++ b/tests/unit/test_parallel_accounts_flag.py
@@ -13,7 +13,7 @@ from src.io import AppConfig
 
 
 def test_parallel_accounts_flag_overrides_config(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, portfolios_csv_path: Path
 ) -> None:
     plan_starts: list[float] = []
 
@@ -64,7 +64,7 @@ def test_parallel_accounts_flag_overrides_config(
 
     args = Namespace(
         config="config/settings.ini",
-        csv=str(Path("..") / "data" / "portfolios.csv"),
+        csv=str(portfolios_csv_path),
         dry_run=True,
         yes=False,
         read_only=False,

--- a/tests/unit/test_portfolio_csv.py
+++ b/tests/unit/test_portfolio_csv.py
@@ -57,10 +57,9 @@ def fake_ib(monkeypatch):
 
 
 @pytest.fixture()
-def portfolios_csv(tmp_path: Path) -> Path:
-    src = Path(__file__).resolve().parents[2] / "data" / "portfolios.csv"
+def portfolios_csv(tmp_path: Path, portfolios_csv_path: Path) -> Path:
     dst = tmp_path / "portfolios.csv"
-    dst.write_text(src.read_text())
+    dst.write_text(portfolios_csv_path.read_text())
     return dst
 
 


### PR DESCRIPTION
## Summary
- use `config/portfolios.csv` via `portfolios_csv_path` fixture
- update tests to rely on new fixture instead of `data/portfolios.csv`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb09311a808320b249fba600550816