### PR TITLE
Avoid duplicate run summary entries on failures

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -611,29 +611,8 @@ async def confirm_global(
                 logging.exception(
                     "Unhandled error processing account %s", account_id, exc_info=res
                 )
-                trades = pl["trades"]
-                buy_usd = sum(t.notional for t in trades if t.action == "BUY")
-                sell_usd = sum(t.notional for t in trades if t.action == "SELL")
                 async with output_lock:
                     print(f"[red]{res}[/red]")
-                    append_run_summary(
-                        Path(cfg.io.report_dir),
-                        ts_dt,
-                        {
-                            "timestamp_run": ts_dt.isoformat(),
-                            "account_id": account_id,
-                            "planned_orders": len(trades),
-                            "submitted": 0,
-                            "filled": 0,
-                            "rejected": 0,
-                            "buy_usd": buy_usd,
-                            "sell_usd": sell_usd,
-                            "pre_leverage": pl["pre_leverage"],
-                            "post_leverage": pl["pre_leverage"],
-                            "status": "failed",
-                            "error": str(res),
-                        },
-                    )
                 failures.append((account_id, str(res)))
         return failures
 
@@ -678,27 +657,6 @@ async def confirm_global(
         except (ConfigError, IBKRError, PlanningError) as exc:
             logging.error("Error processing account %s: %s", account_id, exc)
             print(f"[red]{exc}[/red]")
-            trades = pl["trades"]
-            buy_usd = sum(t.notional for t in trades if t.action == "BUY")
-            sell_usd = sum(t.notional for t in trades if t.action == "SELL")
-            append_run_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": len(trades),
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pl["pre_leverage"],
-                    "post_leverage": pl["pre_leverage"],
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
             failures.append((account_id, str(exc)))
             failed_accounts.add(account_id)
         except Exception as exc:  # noqa: BLE001
@@ -706,27 +664,6 @@ async def confirm_global(
                 "Unexpected error processing account %s", account_id, exc_info=exc
             )
             print(f"[red]{exc}[/red]")
-            trades = pl["trades"]
-            buy_usd = sum(t.notional for t in trades if t.action == "BUY")
-            sell_usd = sum(t.notional for t in trades if t.action == "SELL")
-            append_run_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": len(trades),
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pl["pre_leverage"],
-                    "post_leverage": pl["pre_leverage"],
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
             failures.append((account_id, str(exc)))
             failed_accounts.add(account_id)
         if idx < len(sell_plans) - 1:
@@ -756,54 +693,12 @@ async def confirm_global(
         except (ConfigError, IBKRError, PlanningError) as exc:
             logging.error("Error processing account %s: %s", account_id, exc)
             print(f"[red]{exc}[/red]")
-            trades = pl["trades"]
-            buy_usd = sum(t.notional for t in trades if t.action == "BUY")
-            sell_usd = sum(t.notional for t in trades if t.action == "SELL")
-            append_run_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": len(trades),
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pl["pre_leverage"],
-                    "post_leverage": pl["pre_leverage"],
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
             failures.append((account_id, str(exc)))
         except Exception as exc:  # noqa: BLE001
             logging.exception(
                 "Unexpected error processing account %s", account_id, exc_info=exc
             )
             print(f"[red]{exc}[/red]")
-            trades = pl["trades"]
-            buy_usd = sum(t.notional for t in trades if t.action == "BUY")
-            sell_usd = sum(t.notional for t in trades if t.action == "SELL")
-            append_run_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": len(trades),
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pl["pre_leverage"],
-                    "post_leverage": pl["pre_leverage"],
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
             failures.append((account_id, str(exc)))
         await asyncio.sleep(pacing_sec)
 

--- a/src/rebalance.py
+++ b/src/rebalance.py
@@ -150,24 +150,25 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
             buy_usd = plan["buy_usd"] if plan else 0.0
             sell_usd = plan["sell_usd"] if plan else 0.0
             pre_leverage = plan["pre_leverage"] if plan else 0.0
-            capture_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": planned_orders,
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pre_leverage,
-                    "post_leverage": pre_leverage,
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
+            if not any(r.get("account_id") == account_id for r in summary_rows):
+                capture_summary(
+                    Path(cfg.io.report_dir),
+                    ts_dt,
+                    {
+                        "timestamp_run": ts_dt.isoformat(),
+                        "account_id": account_id,
+                        "planned_orders": planned_orders,
+                        "submitted": 0,
+                        "filled": 0,
+                        "rejected": 0,
+                        "buy_usd": buy_usd,
+                        "sell_usd": sell_usd,
+                        "pre_leverage": pre_leverage,
+                        "post_leverage": pre_leverage,
+                        "status": "failed",
+                        "error": str(exc),
+                    },
+                )
             return None
         except Exception as exc:  # noqa: BLE001
             logging.exception("Unhandled error processing account %s", account_id)
@@ -177,24 +178,25 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
             buy_usd = plan["buy_usd"] if plan else 0.0
             sell_usd = plan["sell_usd"] if plan else 0.0
             pre_leverage = plan["pre_leverage"] if plan else 0.0
-            capture_summary(
-                Path(cfg.io.report_dir),
-                ts_dt,
-                {
-                    "timestamp_run": ts_dt.isoformat(),
-                    "account_id": account_id,
-                    "planned_orders": planned_orders,
-                    "submitted": 0,
-                    "filled": 0,
-                    "rejected": 0,
-                    "buy_usd": buy_usd,
-                    "sell_usd": sell_usd,
-                    "pre_leverage": pre_leverage,
-                    "post_leverage": pre_leverage,
-                    "status": "failed",
-                    "error": str(exc),
-                },
-            )
+            if not any(r.get("account_id") == account_id for r in summary_rows):
+                capture_summary(
+                    Path(cfg.io.report_dir),
+                    ts_dt,
+                    {
+                        "timestamp_run": ts_dt.isoformat(),
+                        "account_id": account_id,
+                        "planned_orders": planned_orders,
+                        "submitted": 0,
+                        "filled": 0,
+                        "rejected": 0,
+                        "buy_usd": buy_usd,
+                        "sell_usd": sell_usd,
+                        "pre_leverage": pre_leverage,
+                        "post_leverage": pre_leverage,
+                        "status": "failed",
+                        "error": str(exc),
+                    },
+                )
             return None
 
     plans: list[Plan] = []
@@ -279,48 +281,50 @@ async def _run(args: argparse.Namespace) -> list[tuple[str, str]]:
                 logging.error("Error processing account %s: %s", account_id, exc)
                 await _print_err(f"[red]{exc}[/red]", output_lock)
                 failures.append((account_id, str(exc)))
-                capture_summary(
-                    Path(cfg.io.report_dir),
-                    ts_dt,
-                    {
-                        "timestamp_run": ts_dt.isoformat(),
-                        "account_id": account_id,
-                        "planned_orders": plan["planned_orders"],
-                        "submitted": 0,
-                        "filled": 0,
-                        "rejected": 0,
-                        "buy_usd": plan["buy_usd"],
-                        "sell_usd": plan["sell_usd"],
-                        "pre_leverage": plan["pre_leverage"],
-                        "post_leverage": plan["pre_leverage"],
-                        "status": "failed",
-                        "error": str(exc),
-                    },
-                )
+                if not any(r.get("account_id") == account_id for r in summary_rows):
+                    capture_summary(
+                        Path(cfg.io.report_dir),
+                        ts_dt,
+                        {
+                            "timestamp_run": ts_dt.isoformat(),
+                            "account_id": account_id,
+                            "planned_orders": plan["planned_orders"],
+                            "submitted": 0,
+                            "filled": 0,
+                            "rejected": 0,
+                            "buy_usd": plan["buy_usd"],
+                            "sell_usd": plan["sell_usd"],
+                            "pre_leverage": plan["pre_leverage"],
+                            "post_leverage": plan["pre_leverage"],
+                            "status": "failed",
+                            "error": str(exc),
+                        },
+                    )
             except Exception as exc:  # noqa: BLE001
                 logging.exception(
                     "Unexpected error processing account %s: %s", account_id, exc
                 )
                 await _print_err(f"[red]{exc}[/red]", output_lock)
                 failures.append((account_id, str(exc)))
-                capture_summary(
-                    Path(cfg.io.report_dir),
-                    ts_dt,
-                    {
-                        "timestamp_run": ts_dt.isoformat(),
-                        "account_id": account_id,
-                        "planned_orders": plan["planned_orders"],
-                        "submitted": 0,
-                        "filled": 0,
-                        "rejected": 0,
-                        "buy_usd": plan["buy_usd"],
-                        "sell_usd": plan["sell_usd"],
-                        "pre_leverage": plan["pre_leverage"],
-                        "post_leverage": plan["pre_leverage"],
-                        "status": "failed",
-                        "error": str(exc),
-                    },
-                )
+                if not any(r.get("account_id") == account_id for r in summary_rows):
+                    capture_summary(
+                        Path(cfg.io.report_dir),
+                        ts_dt,
+                        {
+                            "timestamp_run": ts_dt.isoformat(),
+                            "account_id": account_id,
+                            "planned_orders": plan["planned_orders"],
+                            "submitted": 0,
+                            "filled": 0,
+                            "rejected": 0,
+                            "buy_usd": plan["buy_usd"],
+                            "sell_usd": plan["sell_usd"],
+                            "pre_leverage": plan["pre_leverage"],
+                            "post_leverage": plan["pre_leverage"],
+                            "status": "failed",
+                            "error": str(exc),
+                        },
+                    )
             finally:
                 if idx < len(plans) - 1:
                     await asyncio.sleep(pacing)

--- a/tests/unit/test_confirmation_failure_summary.py
+++ b/tests/unit/test_confirmation_failure_summary.py
@@ -1,0 +1,141 @@
+import asyncio
+import csv
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core import confirmation  # noqa: E402
+from src.core.confirmation import confirm_global  # noqa: E402
+from src.core.sizing import SizedTrade  # noqa: E402
+from src.io import (  # noqa: E402
+    IBKR,
+    IO,
+    Accounts,
+    AppConfig,
+    ConfirmMode,
+    Execution,
+    Models,
+    Pricing,
+    Rebalance,
+)
+from src.io.reporting import append_run_summary  # noqa: E402
+from src.broker.errors import IBKRError  # noqa: E402
+
+
+def test_failing_confirmation_writes_single_summary(tmp_path, monkeypatch):
+    cfg = AppConfig(
+        ibkr=IBKR(host="localhost", port=4001, client_id=1, read_only=False),
+        models=Models(smurf=0.5, badass=0.3, gltr=0.2),
+        rebalance=Rebalance(
+            trigger_mode="band",
+            per_holding_band_bps=0,
+            portfolio_total_band_bps=0,
+            min_order_usd=10,
+            cash_buffer_type="abs",
+            cash_buffer_pct=None,
+            cash_buffer_abs=0.0,
+            allow_fractional=False,
+            max_leverage=1.0,
+            maintenance_buffer_pct=0.0,
+            trading_hours="rth",
+            max_passes=1,
+        ),
+        pricing=Pricing(price_source="last", fallback_to_snapshot=False),
+        execution=Execution(
+            order_type="market",
+            algo_preference="adaptive",
+            fallback_plain_market=False,
+            commission_report_timeout=0.0,
+            wait_before_fallback=0.0,
+            batch_orders=False,
+        ),
+        io=IO(report_dir=str(tmp_path), log_level="INFO"),
+        accounts=Accounts(ids=["ACC1"], confirm_mode=ConfirmMode.GLOBAL),
+    )
+
+    plan = {
+        "account_id": "ACC1",
+        "trades": [SizedTrade("XYZ", "BUY", 1, 10.0)],
+        "drifts": [],
+        "prices": {"XYZ": 10.0},
+        "current": {"CASH": 100.0},
+        "targets": {},
+        "net_liq": 100.0,
+        "pre_gross_exposure": 0.0,
+        "pre_leverage": 0.0,
+        "post_leverage": 0.0,
+        "table": "",
+        "planned_orders": 1,
+        "buy_usd": 10.0,
+        "sell_usd": 0.0,
+    }
+
+    args = SimpleNamespace(dry_run=False, read_only=False, yes=True)
+    ts_dt = datetime.utcnow()
+    summary_path: dict[str, Path] = {}
+
+    async def failing_confirm_per_account(
+        plan,
+        args,
+        cfg,
+        ts_dt,
+        *,
+        client_factory,
+        submit_batch,
+        append_run_summary,
+        write_post_trade_report,
+        compute_drift,
+        prioritize_by_drift,
+        size_orders,
+        output_lock,
+    ):
+        summary_path["path"] = append_run_summary(
+            Path(cfg.io.report_dir),
+            ts_dt,
+            {
+                "timestamp_run": ts_dt.isoformat(),
+                "account_id": plan["account_id"],
+                "planned_orders": plan["planned_orders"],
+                "submitted": 0,
+                "filled": 0,
+                "rejected": 0,
+                "buy_usd": plan["buy_usd"],
+                "sell_usd": plan["sell_usd"],
+                "pre_leverage": plan["pre_leverage"],
+                "post_leverage": plan["pre_leverage"],
+                "status": "failed",
+                "error": "boom",
+            },
+        )
+        raise IBKRError("boom")
+
+    monkeypatch.setattr(confirmation, "confirm_per_account", failing_confirm_per_account)
+
+    failures = asyncio.run(
+        confirm_global(
+            [plan],
+            args,
+            cfg,
+            ts_dt,
+            client_factory=lambda: object(),
+            submit_batch=lambda *a, **k: [],
+            append_run_summary=append_run_summary,
+            write_post_trade_report=lambda *a, **k: tmp_path / "report.json",
+            compute_drift=lambda *a, **k: [],
+            prioritize_by_drift=lambda *a, **k: [],
+            size_orders=lambda *a, **k: ([], 0.0, 0.0),
+            pacing_sec=0.0,
+            parallel_accounts=False,
+        )
+    )
+
+    assert failures == [("ACC1", "boom")]
+    path = summary_path["path"]
+    with path.open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 1
+    assert rows[0]["account_id"] == "ACC1"
+    assert rows[0]["status"] == "failed"


### PR DESCRIPTION
## Summary
- Prevent duplicate run summary rows when account processing fails
- Skip redundant summary logging in global confirmation workflow
- Add regression test to ensure failing confirmations create a single summary entry

## Testing
- `pytest tests/unit/test_confirmation_failure_summary.py -q`
- `pytest tests/unit/test_confirmation_summary_counts.py -q`
- `PYTHONPATH=. pytest tests/unit/test_rebalance_failures.py -q`
- `pytest -q` *(fails: ConfigError: [portfolio:DU111111] missing key: path)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d59e34083209f7f7fc9e32b1011