### PR TITLE
Fix fill lookup for same symbol trades

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -90,7 +90,9 @@ async def confirm_per_account(
         buy_total = 0.0
         sell_total = 0.0
         for t in tr_list:
-            q = lookup.get((t.symbol, t.action)) or lookup.get((t.symbol, None))
+            q = lookup.get((t.symbol, t.action))
+            if q is None:
+                q = lookup.get((t.symbol, None))
             res = q.popleft() if q else {}
             qty_any = res.get("fill_qty")
             if qty_any is None:
@@ -112,7 +114,9 @@ async def confirm_per_account(
         buy_total = 0.0
         sell_total = 0.0
         for t in tr_list:
-            q = lookup.get((t.symbol, t.action)) or lookup.get((t.symbol, None))
+            q = lookup.get((t.symbol, t.action))
+            if q is None:
+                q = lookup.get((t.symbol, None))
             res = q.popleft() if q else {}
             qty_any = res.get("fill_qty")
             if qty_any is None:

--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -528,3 +528,270 @@ def test_confirm_per_account_missing_price(tmp_path):
     row = appended[0]
     assert row["status"] == "failed"
     assert "Missing fill price" in row["error"]
+
+
+def test_confirm_per_account_multiple_same_symbol_trades_ignore_stray_fills(tmp_path):
+    cfg = AppConfig(
+        ibkr=IBKR(host="localhost", port=4001, client_id=1, read_only=False),
+        models=Models(smurf=0.5, badass=0.3, gltr=0.2),
+        rebalance=Rebalance(
+            trigger_mode="band",
+            per_holding_band_bps=0,
+            portfolio_total_band_bps=0,
+            min_order_usd=10,
+            cash_buffer_type="abs",
+            cash_buffer_pct=None,
+            cash_buffer_abs=0.0,
+            allow_fractional=False,
+            max_leverage=1.0,
+            maintenance_buffer_pct=0.0,
+            trading_hours="rth",
+            max_passes=2,
+        ),
+        pricing=Pricing(price_source="last", fallback_to_snapshot=False),
+        execution=Execution(
+            order_type="market",
+            algo_preference="adaptive",
+            fallback_plain_market=False,
+            commission_report_timeout=0.0,
+            wait_before_fallback=0.0,
+            batch_orders=False,
+        ),
+        io=IO(report_dir=str(tmp_path), log_level="INFO"),
+        accounts=Accounts(ids=["ACC1"], confirm_mode=ConfirmMode.PER_ACCOUNT),
+        account_overrides={},
+    )
+
+    plan = {
+        "account_id": "ACC1",
+        "trades": [
+            SizedTrade("XYZ", "BUY", 1, 10.0),
+            SizedTrade("XYZ", "BUY", 2, 20.0),
+        ],
+        "drifts": [],
+        "prices": {"XYZ": 10.0},
+        "current": {"CASH": 1000.0},
+        "targets": {},
+        "net_liq": 1000.0,
+        "pre_gross_exposure": 0.0,
+        "pre_leverage": 0.0,
+        "post_leverage": 0.0,
+        "table": "",
+        "planned_orders": 2,
+        "buy_usd": 30.0,
+        "sell_usd": 0.0,
+    }
+
+    args = SimpleNamespace(dry_run=False, read_only=False, yes=True)
+
+    appended: list[dict[str, Any]] = []
+    captured: dict[str, Any] = {}
+
+    async def submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
+        return [
+            {
+                "symbol": "XYZ",
+                "status": "Filled",
+                "action": "BUY",
+                "fill_qty": 1,
+                "fill_price": 10.0,
+            },
+            {
+                "symbol": "XYZ",
+                "status": "Filled",
+                "fill_qty": 100,
+                "fill_price": 99.0,
+            },
+        ]
+
+    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+        captured["positions"] = positions.copy()
+        captured["prices"] = prices.copy()
+        return []
+
+    def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
+        return []
+
+    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+        return [], 0.0, 0.0
+
+    def append_run_summary(path, ts_dt, row):  # noqa: ARG001
+        appended.append(row)
+
+    def write_post_trade_report(
+        path,
+        ts_dt,
+        account_id,
+        drifts,
+        trades,
+        results,
+        prices_before,
+        net_liq,
+        pre_gross_exposure,
+        pre_leverage,
+        post_gross_exposure_actual,
+        post_leverage_actual,
+        cfg,
+    ):  # noqa: ARG001
+        return path / "report.json"
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            pass
+
+    ts_dt = datetime.utcnow()
+    asyncio.run(
+        confirm_per_account(
+            plan,
+            args,
+            cfg,
+            ts_dt,
+            client_factory=DummyClient,
+            submit_batch=submit_batch,
+            append_run_summary=append_run_summary,
+            write_post_trade_report=write_post_trade_report,
+            compute_drift=compute_drift,
+            prioritize_by_drift=prioritize_by_drift,
+            size_orders=size_orders,
+        )
+    )
+
+    assert captured["positions"]["XYZ"] == 3
+    assert captured["prices"]["XYZ"] == 10.0
+    assert appended[0]["buy_usd"] == 30.0
+
+
+def test_confirm_per_account_totals_skip_unmatched_fills(tmp_path):
+    cfg = AppConfig(
+        ibkr=IBKR(host="localhost", port=4001, client_id=1, read_only=False),
+        models=Models(smurf=0.5, badass=0.3, gltr=0.2),
+        rebalance=Rebalance(
+            trigger_mode="band",
+            per_holding_band_bps=0,
+            portfolio_total_band_bps=0,
+            min_order_usd=10,
+            cash_buffer_type="abs",
+            cash_buffer_pct=None,
+            cash_buffer_abs=0.0,
+            allow_fractional=False,
+            max_leverage=1.0,
+            maintenance_buffer_pct=0.0,
+            trading_hours="rth",
+            max_passes=2,
+        ),
+        pricing=Pricing(price_source="last", fallback_to_snapshot=False),
+        execution=Execution(
+            order_type="market",
+            algo_preference="adaptive",
+            fallback_plain_market=False,
+            commission_report_timeout=0.0,
+            wait_before_fallback=0.0,
+            batch_orders=False,
+        ),
+        io=IO(report_dir=str(tmp_path), log_level="INFO"),
+        accounts=Accounts(ids=["ACC1"], confirm_mode=ConfirmMode.PER_ACCOUNT),
+        account_overrides={},
+    )
+
+    plan = {
+        "account_id": "ACC1",
+        "trades": [
+            SizedTrade("XYZ", "BUY", 1, 10.0),
+            SizedTrade("XYZ", "BUY", 2, 20.0),
+        ],
+        "drifts": [],
+        "prices": {"XYZ": 10.0},
+        "current": {"CASH": 1000.0},
+        "targets": {},
+        "net_liq": 1000.0,
+        "pre_gross_exposure": 0.0,
+        "pre_leverage": 0.0,
+        "post_leverage": 0.0,
+        "table": "",
+        "planned_orders": 2,
+        "buy_usd": 30.0,
+        "sell_usd": 0.0,
+    }
+
+    args = SimpleNamespace(dry_run=False, read_only=False, yes=True)
+
+    appended: list[dict[str, Any]] = []
+
+    async def submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
+        return [
+            {
+                "symbol": "XYZ",
+                "status": "Filled",
+                "action": "BUY",
+                "fill_qty": 1,
+                "fill_price": 10.0,
+            },
+            {
+                "symbol": "XYZ",
+                "status": "Cancelled",
+                "fill_qty": 100,
+                "fill_price": 99.0,
+            },
+        ]
+
+    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+        return []
+
+    def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
+        return []
+
+    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+        return [], 0.0, 0.0
+
+    def append_run_summary(path, ts_dt, row):  # noqa: ARG001
+        appended.append(row)
+
+    def write_post_trade_report(
+        path,
+        ts_dt,
+        account_id,
+        drifts,
+        trades,
+        results,
+        prices_before,
+        net_liq,
+        pre_gross_exposure,
+        pre_leverage,
+        post_gross_exposure_actual,
+        post_leverage_actual,
+        cfg,
+    ):  # noqa: ARG001
+        return path / "report.json"
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):  # noqa: D401
+            pass
+
+    ts_dt = datetime.utcnow()
+    with pytest.raises(IBKRError):
+        asyncio.run(
+            confirm_per_account(
+                plan,
+                args,
+                cfg,
+                ts_dt,
+                client_factory=DummyClient,
+                submit_batch=submit_batch,
+                append_run_summary=append_run_summary,
+                write_post_trade_report=write_post_trade_report,
+                compute_drift=compute_drift,
+                prioritize_by_drift=prioritize_by_drift,
+                size_orders=size_orders,
+            )
+        )
+
+    assert appended
+    row = appended[0]
+    assert row["status"] == "failed"
+    assert row["buy_usd"] == 10.0


### PR DESCRIPTION
## Summary
- prevent mis-assignment of fills when multiple trades for the same symbol exist
- add regression tests for multiple same-symbol trades and stray fills

## Testing
- `pytest`
- `pytest tests/unit/test_confirm_per_account.py::test_confirm_per_account_multiple_same_symbol_trades_ignore_stray_fills tests/unit/test_confirm_per_account.py::test_confirm_per_account_totals_skip_unmatched_fills -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb102a5c7083208bc26946f3a88e4a