### PR TITLE
feat: validate target-only prices

### DIFF
--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -129,6 +129,11 @@ def compute_drift(
     # Union of all symbols from current holdings and targets.
     symbols = set(current_wts) | set(targets)
 
+    # Ensure target-only symbols have associated pricing data.
+    for sym in set(targets) - set(current_wts):
+        if sym != "CASH" and sym not in prices:
+            raise KeyError(f"missing price for {sym}")
+
     drifts: list[Drift] = []
     for symbol in sorted(symbols):
         target = targets.get(symbol, 0.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+
 import pytest
+
 
 @pytest.fixture
 def portfolios_csv_path() -> Path:

--- a/tests/integration/test_parallel_accounts.py
+++ b/tests/integration/test_parallel_accounts.py
@@ -174,7 +174,9 @@ def test_parallel_confirmation_overlap(monkeypatch, tmp_path, portfolios_csv_pat
     assert abs(confirm_starts[1] - confirm_starts[0]) < 0.05
 
 
-def test_serialized_confirmation_output(monkeypatch, capsys, tmp_path, portfolios_csv_path):
+def test_serialized_confirmation_output(
+    monkeypatch, capsys, tmp_path, portfolios_csv_path
+):
     """Exceptions during serialized confirmation print atomically."""
 
     monkeypatch.setattr(rebalance, "IBKRClient", DummyClient)

--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -489,13 +489,17 @@ def test_confirm_per_account_missing_price(tmp_path):
     ):
         return path / "report.json"
 
-    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+    def compute_drift(
+        account_id, positions, targets, prices, net_liq, cfg
+    ):  # noqa: ARG001
         return []
 
     def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
         return []
 
-    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+    def size_orders(
+        account_id, drifts, prices, cash_after, net_liq, cfg
+    ):  # noqa: ARG001
         return [], 0.0, 0.0
 
     class DummyClient:
@@ -604,7 +608,9 @@ def test_confirm_per_account_multiple_same_symbol_trades_ignore_stray_fills(tmp_
             },
         ]
 
-    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+    def compute_drift(
+        account_id, positions, targets, prices, net_liq, cfg
+    ):  # noqa: ARG001
         captured["positions"] = positions.copy()
         captured["prices"] = prices.copy()
         return []
@@ -612,7 +618,9 @@ def test_confirm_per_account_multiple_same_symbol_trades_ignore_stray_fills(tmp_
     def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
         return []
 
-    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+    def size_orders(
+        account_id, drifts, prices, cash_after, net_liq, cfg
+    ):  # noqa: ARG001
         return [], 0.0, 0.0
 
     def append_run_summary(path, ts_dt, row):  # noqa: ARG001
@@ -737,13 +745,17 @@ def test_confirm_per_account_totals_skip_unmatched_fills(tmp_path):
             },
         ]
 
-    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+    def compute_drift(
+        account_id, positions, targets, prices, net_liq, cfg
+    ):  # noqa: ARG001
         return []
 
     def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
         return []
 
-    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+    def size_orders(
+        account_id, drifts, prices, cash_after, net_liq, cfg
+    ):  # noqa: ARG001
         return [], 0.0, 0.0
 
     def append_run_summary(path, ts_dt, row):  # noqa: ARG001

--- a/tests/unit/test_confirmation_failure_summary.py
+++ b/tests/unit/test_confirmation_failure_summary.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+from src.broker.errors import IBKRError  # noqa: E402
 from src.core import confirmation  # noqa: E402
 from src.core.confirmation import confirm_global  # noqa: E402
 from src.core.sizing import SizedTrade  # noqa: E402
@@ -22,7 +23,6 @@ from src.io import (  # noqa: E402
     Rebalance,
 )
 from src.io.reporting import append_run_summary  # noqa: E402
-from src.broker.errors import IBKRError  # noqa: E402
 
 
 def test_failing_confirmation_writes_single_summary(tmp_path, monkeypatch):
@@ -112,7 +112,9 @@ def test_failing_confirmation_writes_single_summary(tmp_path, monkeypatch):
         )
         raise IBKRError("boom")
 
-    monkeypatch.setattr(confirmation, "confirm_per_account", failing_confirm_per_account)
+    monkeypatch.setattr(
+        confirmation, "confirm_per_account", failing_confirm_per_account
+    )
 
     failures = asyncio.run(
         confirm_global(

--- a/tests/unit/test_confirmation_independent.py
+++ b/tests/unit/test_confirmation_independent.py
@@ -58,7 +58,9 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, tmp_path, records, executed):
     monkeypatch.setattr(rebalance.asyncio, "sleep", fake_sleep)
 
 
-def test_independent_confirmation_statuses(monkeypatch, tmp_path, portfolios_csv_path: Path):
+def test_independent_confirmation_statuses(
+    monkeypatch, tmp_path, portfolios_csv_path: Path
+):
     records: list[dict[str, str]] = []
     executed: list[str] = []
     _patch_common(monkeypatch, tmp_path, records, executed)

--- a/tests/unit/test_confirmation_modes.py
+++ b/tests/unit/test_confirmation_modes.py
@@ -71,7 +71,9 @@ def test_per_account_prompts_once_per_account(
     assert prompts == ["Proceed? [y/N]: ", "Proceed? [y/N]: "]
 
 
-def test_global_prompt_once_and_aborts(monkeypatch, tmp_path, capsys, portfolios_csv_path: Path):
+def test_global_prompt_once_and_aborts(
+    monkeypatch, tmp_path, capsys, portfolios_csv_path: Path
+):
     records: list[dict[str, str]] = []
 
     def fake_append(report_dir, ts, row):  # noqa: ARG001

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -123,6 +123,18 @@ def test_compute_drift_buffer_exceeds_net_liq_raises() -> None:
         compute_drift("ACCT", current, targets, prices, net_liq, cfg)
 
 
+def test_compute_drift_missing_price_for_target_raises() -> None:
+    """A KeyError is raised when a target symbol lacks pricing data."""
+
+    current = {"AAA": 10, "CASH": 5000}
+    targets = {"AAA": 50.0, "BBB": 50.0}
+    prices = {"AAA": 100.0}  # Missing BBB price
+    net_liq = 6000.0
+
+    with pytest.raises(KeyError):
+        compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
+
+
 def test_compute_drift_defaults_missing_targets_to_zero() -> None:
     """Symbols absent from targets are treated as having 0% target weight."""
 


### PR DESCRIPTION
## Summary
- ensure target-only symbols have price data in `compute_drift`
- add test for missing price in targets

## Testing
- `pre-commit run --files src/core/drift.py tests/unit/test_drift.py`
- `pytest tests/unit/test_drift.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb126efb1083209d69971832f2aa18