### PR TITLE
Cancel timed-out orders and add test

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -146,6 +146,16 @@ async def submit_batch(
                 status = getattr(ib_trade.orderStatus, "status", "")
 
         if status != "Filled":
+            try:
+                ib.cancelOrder(ib_trade.order)
+                await _wait(ib_trade, st.symbol)
+            except Exception as exc:  # pragma: no cover - network errors
+                log.warning(
+                    "Failed to cancel order %s for %s: %s",
+                    getattr(getattr(ib_trade, "order", None), "orderId", None),
+                    st.symbol,
+                    exc,
+                )
             raise IBKRError(
                 f"order submission for {st.symbol} failed with status {status}"
             )


### PR DESCRIPTION
## Summary
- cancel and await unfilled orders before raising execution errors
- log network errors when order cancellation fails
- test that timed-out orders are cancelled when no fallback is used

## Testing
- `PYTHONPATH=. pytest tests/unit/test_execution.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb1b3fecf8832097012bde3d9eeccb