### PR TITLE
Format config loader and tests

### DIFF
--- a/src/io/config_loader.py
+++ b/src/io/config_loader.py
@@ -325,7 +325,9 @@ def load_config(path: Path) -> AppConfig:
 
     unknown_accounts = sorted(set(portfolio_paths) - set(accounts.ids))
     if unknown_accounts:
-        raise ConfigError("[account] unknown account ids: " + ", ".join(unknown_accounts))
+        raise ConfigError(
+            "[account] unknown account ids: " + ", ".join(unknown_accounts)
+        )
 
     # [models]
     data = _load_section(cp, "models")

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -69,9 +69,7 @@ log_level = INFO
 
 
 # Configuration variant with a per-account portfolio path override.
-VALID_CONFIG_WITH_ACCOUNT_PATH = (
-    VALID_CONFIG + "\n[account: acc1]\npath = foo.csv\n"
-)
+VALID_CONFIG_WITH_ACCOUNT_PATH = VALID_CONFIG + "\n[account: acc1]\npath = foo.csv\n"
 
 
 @pytest.fixture
@@ -368,9 +366,7 @@ def test_account_id_normalization(tmp_path: Path) -> None:
 
 
 def test_portfolio_override_unknown_account(tmp_path: Path) -> None:
-    content = (
-        VALID_CONFIG_WITH_ACCOUNT_PATH + "\n[account: acc3 ]\npath = foo.csv\n"
-    )
+    content = VALID_CONFIG_WITH_ACCOUNT_PATH + "\n[account: acc3 ]\npath = foo.csv\n"
     path = tmp_path / "settings.ini"
     path.write_text(content)
     (path.parent / "foo.csv").write_text("")


### PR DESCRIPTION
## Summary
- reformat config loader to wrap long error message
- tidy test config strings to satisfy black

## Testing
- `pre-commit run --files src/io/config_loader.py tests/unit/test_config_loader.py`
- `pytest`
- `black --check src/io/config_loader.py tests/unit/test_config_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb1f376d2c83208fabd5221142d0ac