### PR TITLE
Use synchronous IB disconnect to satisfy mypy

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -83,7 +83,7 @@ async def validate_symbols(
             raise PortfolioCSVError(f"IB connection failed: {exc}") from exc
     finally:
         try:
-            await ib.disconnectAsync()
+            ib.disconnect()
         except Exception:
             pass
 

--- a/tests/unit/test_validate_symbols.py
+++ b/tests/unit/test_validate_symbols.py
@@ -36,7 +36,7 @@ class FakeIB:
     ):  # noqa: N803 (upstream uses camelCase)
         self.connected = True
 
-    async def disconnectAsync(self):
+    def disconnect(self):
         self.disconnects += 1
         self.connected = False
         if self.raise_disconnect:


### PR DESCRIPTION
## Summary
- use the synchronous `disconnect` method from `ib_async.IB` when validating symbols
- adjust unit tests to expect `disconnect` instead of `disconnectAsync`

## Testing
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb20dfb38083209bec2fbe7e6eb35d