### PR TITLE
Make expected columns optional in portfolio loader

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -173,9 +173,10 @@ def _validate_totals(portfolios: Dict[str, Dict[str, float]]) -> None:
 
 
 async def load_portfolios_map(
-    paths: Mapping[str, Path], *, host: str, port: int, client_id: int
+    paths: Mapping[str, Path], *, host: str, port: int, client_id: int,
+    expected: list[str] | None = None,
 ) -> dict[str, dict[str, dict[str, float]]]:
-    expected: list[str] | None = ["ETF", "SMURF", "BADASS", "GLTR"]
+    expected = expected or ["ETF", "SMURF", "BADASS", "GLTR"]
     cache: Dict[Path, dict[str, dict[str, float]]] = {}
     result: Dict[str, dict[str, dict[str, float]]] = {}
     symbols: set[str] = set()


### PR DESCRIPTION
## Summary
- allow custom column expectations in `load_portfolios_map`
- default to ETF/SMURF/BADASS/GLTR when expectation is unspecified

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb25a88c448320a07312ad69d8cd5a