### PR TITLE
Propagate global confirmation

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -5,8 +5,8 @@ import logging
 from collections import defaultdict, deque
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping, cast
 from types import SimpleNamespace
+from typing import Any, Mapping, cast
 
 from rich import print
 

--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -6,6 +6,7 @@ from collections import defaultdict, deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, cast
+from types import SimpleNamespace
 
 from rich import print
 
@@ -491,6 +492,8 @@ async def confirm_global(
 ) -> list[tuple[str, str]]:
     """Handle global confirmation workflow for multiple accounts."""
 
+    args = SimpleNamespace(**vars(args))
+
     for plan in plans:
         print(plan["table"])
 
@@ -580,6 +583,7 @@ async def confirm_global(
                     },
                 )
             return failures
+        args.yes = True
 
     use_parallel = parallel_accounts and args.yes and pacing_sec == 0
     output_lock: asyncio.Lock | None = None

--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -173,7 +173,11 @@ def _validate_totals(portfolios: Dict[str, Dict[str, float]]) -> None:
 
 
 async def load_portfolios_map(
-    paths: Mapping[str, Path], *, host: str, port: int, client_id: int,
+    paths: Mapping[str, Path],
+    *,
+    host: str,
+    port: int,
+    client_id: int,
     expected: list[str] | None = None,
 ) -> dict[str, dict[str, dict[str, float]]]:
     expected = expected or ["ETF", "SMURF", "BADASS", "GLTR"]


### PR DESCRIPTION
## Summary
- clone CLI args in `confirm_global` so global confirmation sets downstream `yes`
- pass updated args to `confirm_per_account` to skip extra prompts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb263a9da08320a62d92f0e95cedbc