### PR TITLE
Handle network errors explicitly in portfolio CSV

### DIFF
--- a/src/io/portfolio_csv.py
+++ b/src/io/portfolio_csv.py
@@ -79,7 +79,10 @@ async def validate_symbols(
                     or cd.stockType != "ETF"
                 ):
                     raise PortfolioCSVError(f"{symbol}: not a USD-denominated ETF")
-        except Exception as exc:  # pragma: no cover - network failure
+        except OSError as exc:  # pragma: no cover - network failure
+            # Limit this handler to connection-related issues so that
+            # PortfolioCSVError raised above (e.g., unknown symbols) is not
+            # swallowed and users can see the actual validation problem.
             raise PortfolioCSVError(f"IB connection failed: {exc}") from exc
     finally:
         try:

--- a/tests/unit/test_validate_symbols.py
+++ b/tests/unit/test_validate_symbols.py
@@ -99,7 +99,7 @@ def test_connection_failure(monkeypatch) -> None:
     ib = setup_fake_ib(monkeypatch)
 
     async def fail_connect(host, port, clientId):  # noqa: N803 - mimics upstream
-        raise RuntimeError("boom")
+        raise OSError("boom")
 
     setattr(ib, "connectAsync", fail_connect)
     with pytest.raises(PortfolioCSVError) as excinfo:


### PR DESCRIPTION
## Summary
- Narrow IB connection error handling to `OSError` so validation failures surface as `PortfolioCSVError`
- Adjust tests to expect `OSError` for simulated connection failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb27000f448320b2e415d686aebffc