### PR TITLE
Include explicit action in execution results

### DIFF
--- a/src/broker/execution.py
+++ b/src/broker/execution.py
@@ -291,6 +291,7 @@ async def submit_batch(
         except Exception:  # pragma: no cover - defensive
             pass
         return {
+            "action": st.action,
             "symbol": st.symbol,
             "order_id": getattr(ib_trade.order, "orderId", None),
             "status": status,

--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -92,8 +92,6 @@ async def confirm_per_account(
         sell_total = 0.0
         for t in tr_list:
             q = lookup.get((t.symbol, t.action))
-            if q is None:
-                q = lookup.get((t.symbol, None))
             res = q.popleft() if q else {}
             qty_any = res.get("fill_qty")
             if qty_any is None:
@@ -116,8 +114,6 @@ async def confirm_per_account(
         sell_total = 0.0
         for t in tr_list:
             q = lookup.get((t.symbol, t.action))
-            if q is None:
-                q = lookup.get((t.symbol, None))
             res = q.popleft() if q else {}
             qty_any = res.get("fill_qty")
             if qty_any is None:

--- a/src/io/reporting.py
+++ b/src/io/reporting.py
@@ -195,8 +195,10 @@ def write_post_trade_report(
         "notes",
     ]
 
-    trades_by_symbol = {t.symbol: t for t in trades}
-    results_by_symbol = {r.get("symbol"): r for r in results}
+    trades_by_key = {(t.symbol, t.action): t for t in trades}
+    results_by_key = {
+        (r.get("symbol"), r.get("action")): r for r in results
+    }
     timestamp_run = ts.isoformat()
     order_type = cfg.execution.order_type
     algo = cfg.execution.algo_preference
@@ -205,8 +207,8 @@ def write_post_trade_report(
         writer = csv.DictWriter(fh, fieldnames=fieldnames)
         writer.writeheader()
         for d in sorted(drifts, key=lambda d: d.symbol):
-            trade = trades_by_symbol.get(d.symbol)
-            res = results_by_symbol.get(d.symbol, {})
+            trade = trades_by_key.get((d.symbol, d.action))
+            res = results_by_key.get((d.symbol, d.action), {})
             planned_qty = trade.quantity if trade else 0.0
             est_price = prices.get(d.symbol, 1.0 if d.symbol == "CASH" else 0.0)
             est_value = trade.notional if trade else 0.0

--- a/tests/integration/test_rebalance_confirmation.py
+++ b/tests/integration/test_rebalance_confirmation.py
@@ -107,6 +107,7 @@ def test_yes_skips_prompt(
         return [
             {
                 "symbol": t.symbol,
+                "action": t.action,
                 "status": "Filled",
                 "filled": t.quantity,
                 "avg_fill_price": 0.0,
@@ -189,6 +190,7 @@ def test_yes_skips_prompt_global(
         return [
             {
                 "symbol": t.symbol,
+                "action": t.action,
                 "status": "Filled",
                 "filled": t.quantity,
                 "avg_fill_price": 0.0,

--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -199,6 +199,7 @@ def test_confirm_per_account_reports_totals_for_same_symbol_buys_and_sells(tmp_p
             results.append(
                 {
                     "symbol": t.symbol,
+                    "action": t.action,
                     "status": "Filled",
                     "fill_qty": t.quantity,
                     "fill_price": price,
@@ -330,6 +331,7 @@ def test_confirm_per_account_logs_failed_summary(tmp_path):
         return [
             {
                 "symbol": trades[0].symbol,
+                "action": trades[0].action,
                 "status": "Rejected",
                 "fill_qty": 0,
                 "fill_price": 0.0,
@@ -464,6 +466,7 @@ def test_confirm_per_account_missing_price(tmp_path):
         return [
             {
                 "symbol": trades[0].symbol,
+                "action": trades[0].action,
                 "status": "Filled",
                 "fill_qty": trades[0].quantity,
             }
@@ -603,6 +606,7 @@ def test_confirm_per_account_multiple_same_symbol_trades_ignore_stray_fills(tmp_
             {
                 "symbol": "XYZ",
                 "status": "Filled",
+                "action": "SELL",
                 "fill_qty": 100,
                 "fill_price": 99.0,
             },
@@ -740,6 +744,7 @@ def test_confirm_per_account_totals_skip_unmatched_fills(tmp_path):
             {
                 "symbol": "XYZ",
                 "status": "Cancelled",
+                "action": "SELL",
                 "fill_qty": 100,
                 "fill_price": 99.0,
             },

--- a/tests/unit/test_confirmation_summary_counts.py
+++ b/tests/unit/test_confirmation_summary_counts.py
@@ -81,6 +81,7 @@ def test_summary_reports_planned_and_executed_counts(tmp_path):
             results.append(
                 {
                     "symbol": t.symbol,
+                    "action": t.action,
                     "status": "Filled",
                     "fill_qty": t.quantity,
                     "fill_price": 10.0,

--- a/tests/unit/test_rebalance_faults.py
+++ b/tests/unit/test_rebalance_faults.py
@@ -147,6 +147,7 @@ def test_global_confirmation_pacing(monkeypatch: pytest.MonkeyPatch) -> None:
         return [
             {
                 "symbol": t.symbol,
+                "action": t.action,
                 "status": "Filled",
                 "fill_qty": t.quantity,
                 "fill_price": 1.0,

--- a/tests/unit/test_rebalance_submit.py
+++ b/tests/unit/test_rebalance_submit.py
@@ -84,7 +84,13 @@ def test_run_submits_orders_and_prints_summary(monkeypatch, capsys):
         recorded["trades"] = trades
         recorded["account_id"] = account_id
         return [
-            {"symbol": "AAA", "status": "Filled", "filled": 5.0, "avg_fill_price": 10.0}
+            {
+                "symbol": "AAA",
+                "action": "BUY",
+                "status": "Filled",
+                "filled": 5.0,
+                "avg_fill_price": 10.0,
+            }
         ]
 
     monkeypatch.setattr(rebalance, "submit_batch", fake_submit_batch)
@@ -106,6 +112,7 @@ def test_run_logs_error_on_order_failure(monkeypatch, capsys):
         return [
             {
                 "symbol": "AAA",
+                "action": "BUY",
                 "status": "Rejected",
                 "filled": 0.0,
                 "avg_fill_price": 0.0,
@@ -132,6 +139,7 @@ def test_run_performs_additional_pass(monkeypatch):
         return [
             {
                 "symbol": t.symbol,
+                "action": t.action,
                 "status": "Filled",
                 "filled": t.quantity,
                 "avg_fill_price": 10.0,

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -116,6 +116,7 @@ def test_write_pre_and_post_trade_reports(tmp_path, caplog):
     results = [
         {
             "symbol": "AAA",
+            "action": "BUY",
             "status": "Filled",
             "filled": 8.0,
             "avg_fill_price": 110.0,
@@ -228,6 +229,7 @@ def test_post_trade_missing_execid_notes(tmp_path):
     results = [
         {
             "symbol": "AAA",
+            "action": "BUY",
             "status": "Filled",
             "filled": 10.0,
             "avg_fill_price": 100.0,


### PR DESCRIPTION
## Summary
- Add `action` attribute to execution results and utilize it in confirmation and reporting
- Remove fallback symbol-only matching so fills match by symbol and action
- Update tests to reflect new `action` field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2e99bab88320856038781654a209