### PR TITLE
Use IBKR MIDPRICE order type with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,12 @@ timestamp_run,account_id,planned_orders,submitted,filled,rejected,buy_usd,sell_u
 
 ### Order execution module
 `src/broker/execution.py` submits the confirmed trades and supports IBKR's
-`none`, Adaptive, or Midprice algos via `execution.algo_preference`. Submitted orders
-are tagged with their account code so Interactive Brokers books them correctly.
-If the selected algo is rejected and `fallback_plain_market` is true, it retries
-with a plain market order. Trading hours are controlled by
+`none`, Adaptive, or Midprice algos via `execution.algo_preference`. Midprice
+uses the dedicated MIDPRICE order type pegged to the NBBO midpoint and may be
+rejected if the account lacks entitlement or the market does not support it.
+Submitted orders are tagged with their account code so Interactive Brokers
+books them correctly. If the selected algo is rejected and
+`fallback_plain_market` is true, it retries with a plain market order. Trading hours are controlled by
 `rebalance.trading_hours`: use `eth` to allow extended-hours trading (setting
 `outsideRth=True` on market orders) or the default `rth` to rely on IBKR's
 regular-hours enforcement. Order submissions log each status transition with

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -75,7 +75,13 @@ fallback_to_snapshot = true
 [execution]
 ; Order type (market only)
 order_type = market
-; Preferred algo: none | adaptive | midprice. Use 'none' for plain market orders. For execution certainty (e.g., rebalancing portfolios) use Adaptive. Use Midprice when spreads are wide, liquidity is decent, and you want cost savings but risk not being filled.
+; Preferred algo: none | adaptive | midprice.
+; 'midprice' uses IBKR's MIDPRICE order type pegged to the NBBO midpoint
+; and may be rejected if the account lacks entitlement or the venue does
+; not support midpoint orders. Use 'none' for plain market orders. For
+; execution certainty (e.g., rebalancing portfolios) use Adaptive. Use
+; Midprice when spreads are wide, liquidity is decent, and you want cost
+; savings but risk not being filled.
 algo_preference = none
 ; true falls back to plain market if algo fails
 fallback_plain_market = true


### PR DESCRIPTION
## Summary
- replace ArrivalPx midpoint algorithm with IBKR MIDPRICE order type
- document Midprice order requirements and limitations
- test Midprice order handling and fallback to market

## Testing
- `PYTHONPATH=. pytest -q tests/unit/test_execution.py`
- `pre-commit run --files src/broker/execution.py tests/unit/test_execution.py config/settings.ini README.md`


------
https://chatgpt.com/codex/tasks/task_e_68bb30b2efa883208cc51eb272c65bb2