### PR TITLE
Format code with Black

### DIFF
--- a/src/core/confirmation.py
+++ b/src/core/confirmation.py
@@ -118,16 +118,12 @@ async def confirm_per_account(
             q = lookup.get((t.symbol, t.action))
             res = q.popleft() if q else {}
             if not res:
-                raise IBKRError(
-                    f"Missing fill result for {t.symbol} {t.action}"
-                )
+                raise IBKRError(f"Missing fill result for {t.symbol} {t.action}")
             qty_any = res.get("fill_qty")
             if qty_any is None:
                 qty_any = res.get("filled")
             if qty_any is None:
-                raise IBKRError(
-                    f"Missing fill quantity for {t.symbol} {t.action}"
-                )
+                raise IBKRError(f"Missing fill quantity for {t.symbol} {t.action}")
             filled = float(qty_any)
             price_any = res.get("fill_price")
             if price_any is None:

--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -593,13 +593,17 @@ def test_confirm_per_account_missing_result_entry(tmp_path):
     async def submit_batch(client, trades, cfg, account_id):  # noqa: ARG001
         return []
 
-    def compute_drift(account_id, positions, targets, prices, net_liq, cfg):  # noqa: ARG001
+    def compute_drift(
+        account_id, positions, targets, prices, net_liq, cfg
+    ):  # noqa: ARG001
         return []
 
     def prioritize_by_drift(account_id, drifts, cfg):  # noqa: ARG001
         return []
 
-    def size_orders(account_id, drifts, prices, cash_after, net_liq, cfg):  # noqa: ARG001
+    def size_orders(
+        account_id, drifts, prices, cash_after, net_liq, cfg
+    ):  # noqa: ARG001
         return [], 0.0, 0.0
 
     def append_run_summary(path, ts_dt, row):  # noqa: ARG001


### PR DESCRIPTION
## Summary
- run Black formatting on core confirmation and its test

## Testing
- `black --check src/core/confirmation.py tests/unit/test_confirm_per_account.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb3698c8708320aa8e820709eb6a2a