### PR TITLE
Add validate_config CLI tests and remove placeholders

### DIFF
--- a/tests/integration/test_integration_placeholder.py
+++ b/tests/integration/test_integration_placeholder.py
@@ -1,7 +1,0 @@
-import pytest
-
-pytestmark = pytest.mark.integration
-
-
-def test_integration_placeholder():
-    assert True

--- a/tests/unit/test_placeholder.py
+++ b/tests/unit/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/tests/unit/test_validate_config_cli.py
+++ b/tests/unit/test_validate_config_cli.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_ok() -> None:
+    cfg = Path(__file__).resolve().parents[2] / "config" / "settings.ini"
+    result = subprocess.run(
+        [sys.executable, "-m", "src.io.validate_config", str(cfg)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "Config OK"
+
+
+def test_cli_error(tmp_path: Path) -> None:
+    bad_cfg = tmp_path / "settings.ini"
+    bad_cfg.write_text(
+        """
+[ibkr]
+host = 127.0.0.1
+port = 4002
+client_id = 42
+read_only = true
+"""
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "src.io.validate_config", str(bad_cfg)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Missing section [accounts]" in result.stdout


### PR DESCRIPTION
## Summary
- remove placeholder unit and integration tests
- add tests for validate_config CLI covering success and failure cases

## Testing
- `pre-commit run --files tests/unit/test_validate_config_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4a2bf3588320998f1a519b1bbcbd