### PR TITLE
Remove unused top-level exports

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,8 +1,0 @@
-"""Top-level package for IB_Simple."""
-
-from .io.portfolio_csv import PortfolioCSVError, load_portfolios
-
-__all__ = [
-    "PortfolioCSVError",
-    "load_portfolios",
-]

--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from src.io import ConfigError
+from src.io.config_loader import ConfigError
 
 
 @dataclass(frozen=True)

--- a/src/core/sizing.py
+++ b/src/core/sizing.py
@@ -20,7 +20,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from src.io import merge_account_overrides
+from src.io.config_loader import merge_account_overrides
 
 from .drift import Drift
 

--- a/src/io/__init__.py
+++ b/src/io/__init__.py
@@ -27,12 +27,6 @@ from .portfolio_csv import (
     load_portfolios_map,
     validate_symbols,
 )
-from .reporting import (
-    append_run_summary,
-    setup_logging,
-    write_post_trade_report,
-    write_pre_trade_report,
-)
 
 __all__ = [
     "AppConfig",
@@ -58,3 +52,16 @@ __all__ = [
     "write_post_trade_report",
     "append_run_summary",
 ]
+
+
+def __getattr__(name: str):
+    if name in {
+        "append_run_summary",
+        "setup_logging",
+        "write_post_trade_report",
+        "write_pre_trade_report",
+    }:
+        from . import reporting
+
+        return getattr(reporting, name)
+    raise AttributeError(name)

--- a/src/io/validate_config.py
+++ b/src/io/validate_config.py
@@ -1,0 +1,27 @@
+"""CLI utility to validate configuration files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config_loader import ConfigError, load_config
+
+
+def main(path: str) -> None:
+    """Validate the given config printing ``Config OK`` on success."""
+
+    try:
+        load_config(Path(path))
+    except (ConfigError, OSError) as exc:  # pragma: no cover - simple wrapper
+        print(exc)
+        raise SystemExit(1)
+    print("Config OK")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config_path", help="Path to settings.ini")
+    args = parser.parse_args()
+    main(args.config_path)


### PR DESCRIPTION
## Summary
- drop unused top-level re-exports by deleting `src/__init__.py`
- import config helpers directly to prevent circular imports
- lazily expose reporting utilities and add a config validation CLI

## Testing
- `pre-commit run --files src/core/drift.py src/core/sizing.py src/io/__init__.py src/io/validate_config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc4d93ec0883209e4de3b34ed3b013