### PR TITLE
docs: expand conda quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ FIRST TIME
 cd IB_Trade
 conda create -n ibkr-rebal python=3.10 -y
 conda activate ibkr-rebal
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
+pre-commit install
+pytest -q -m "not integration"  # optional
 python -m src.rebalance --config config/settings.ini
 ```
 FYI: The `-m` option tells Python to treat the following argument (src.rebalance) as a module name rather than a file path.


### PR DESCRIPTION
## Summary
- document installing dev requirements and pre-commit in Conda quickstart
- mention optional pytest command for non-integration tests

## Testing
- `python -m pre_commit run --files README.md`
- `pytest -q -m "not integration"` *(fails: No module named src.io.validate_config)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4eb20dc8832081050e73d3bb75ee