### PR TITLE
Document cash sweep passes and batch submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ mixing global and per-account files:
 python -m src.rebalance --config config/settings.ini --csv config/portfolios.csv
 ```
 
+### Rebalance passes
+
+The `[rebalance]` section controls how many times the tool sweeps leftover cash
+after the initial trades fill. The `max_passes` setting caps these repeated
+cash sweeps; each pass recalculates drift and submits additional batches until
+remaining cash falls below `min_order_usd` or the limit is reached. The sample
+`config/settings.ini` enables three passes by default with `max_passes = 3`.
+
+### Batch order submission
+
+Under `[execution]`, `batch_orders` determines whether orders are grouped before
+being sent to IBKR. When enabled, submissions are bundled into batches instead
+of dispatched one by one, reducing API round-trips. The default configuration
+has `batch_orders = true` in `config/settings.ini`.
+
 ## Usage
 
 ### Validate configuration


### PR DESCRIPTION
## Summary
- Document `[rebalance]`'s `max_passes` setting and how it repeats cash sweeps
- Explain `[execution]`'s `batch_orders` option for grouping submissions

## Testing
- `pre-commit run --files README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc50df56348320bd21f6fe76b8c97a