### PR TITLE
feat: add config validation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,13 @@ has `batch_orders = true` in `config/settings.ini`.
 ## Usage
 
 ### Validate configuration
-The configuration can be checked by loading it with `load_config()`:
+Check the configuration from the command line:
 
 ```bash
-python - <<'PY'
-from pathlib import Path
-from src.io.config_loader import load_config
-load_config(Path("config/settings.ini"))
-print("Config OK")
-PY
+python -m src.io.validate_config config/settings.ini
 ```
+
+This prints `Config OK` when the file is valid.
 
 `validate_portfolios.py` also validates the configuration before checking
 portfolio files.

--- a/src/io/validate_config.py
+++ b/src/io/validate_config.py
@@ -1,4 +1,13 @@
-"""CLI utility to validate configuration files."""
+"""Validate configuration files.
+
+This module exposes a tiny CLI::
+
+    python -m src.io.validate_config <path>
+
+Running the command loads the configuration file and prints ``Config OK`` if
+the file is valid.  Otherwise, the error is printed and the process exits with
+a non-zero status code.
+"""
 
 from __future__ import annotations
 
@@ -6,12 +15,14 @@ from pathlib import Path
 
 from .config_loader import ConfigError, load_config
 
+__all__ = ["main"]
 
-def main(path: str) -> None:
+
+def main(config_path: str) -> None:
     """Validate the given config printing ``Config OK`` on success."""
 
     try:
-        load_config(Path(path))
+        load_config(Path(config_path))
     except (ConfigError, OSError) as exc:  # pragma: no cover - simple wrapper
         print(exc)
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add `src.io.validate_config` CLI to validate settings files
- document config validation command in README

## Testing
- `pre-commit run --files README.md src/io/validate_config.py`
- `pytest tests/unit/test_validate_config_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc520f42c483208e0bfbb4a8840768