### PR TITLE
Remove demo from preview module and add example script

### DIFF
--- a/examples/preview_demo.py
+++ b/examples/preview_demo.py
@@ -1,0 +1,37 @@
+"""Demonstration of :func:`src.core.preview.render`."""
+
+from __future__ import annotations
+
+from src.core.drift import Drift
+from src.core.preview import render
+from src.core.sizing import SizedTrade
+
+
+def main() -> None:
+    sample_plan = [
+        Drift("AAA", 50.0, 60.0, 10.0, 640.0, "SELL"),
+        Drift("BBB", 50.0, 40.0, -10.0, -640.0, "BUY"),
+    ]
+    sample_trades = [
+        SizedTrade("AAA", "SELL", 6.4, 640.0),
+        SizedTrade("BBB", "BUY", 7.111111, 640.0),
+    ]
+    pre_exp = 1000.0
+    pre_lev = 1.0
+    post_exp = pre_exp - 640.0 + 640.0  # no change in this demo
+    post_lev = post_exp / (pre_exp / pre_lev)
+    print(
+        render(
+            "DEMO",
+            sample_plan,
+            sample_trades,
+            pre_exp,
+            pre_lev,
+            post_exp,
+            post_lev,
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()

--- a/src/core/preview.py
+++ b/src/core/preview.py
@@ -17,6 +17,8 @@ from rich.table import Table
 from .drift import Drift
 from .sizing import SizedTrade
 
+__all__ = ["render"]
+
 
 def render(
     account_id: str,
@@ -132,29 +134,3 @@ def render(
     console.print()
     console.print(summary)
     return console.export_text()
-
-
-if __name__ == "__main__":  # pragma: no cover - convenience demo
-    sample_plan = [
-        Drift("AAA", 50.0, 60.0, 10.0, 640.0, "SELL"),
-        Drift("BBB", 50.0, 40.0, -10.0, -640.0, "BUY"),
-    ]
-    sample_trades = [
-        SizedTrade("AAA", "SELL", 6.4, 640.0),
-        SizedTrade("BBB", "BUY", 7.111111, 640.0),
-    ]
-    pre_exp = 1000.0
-    pre_lev = 1.0
-    post_exp = pre_exp - 640.0 + 640.0  # no change in this demo
-    post_lev = post_exp / (pre_exp / pre_lev)
-    print(
-        render(
-            "DEMO",
-            sample_plan,
-            sample_trades,
-            pre_exp,
-            pre_lev,
-            post_exp,
-            post_lev,
-        )
-    )


### PR DESCRIPTION
## Summary
- strip `__main__` demo from `src/core/preview.py` and limit exports to `render`
- add `examples/preview_demo.py` showcasing how to render a drift table

## Testing
- `pre-commit run --files src/core/preview.py examples/preview_demo.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc517619248320b354c2a0530b31a5