### PR TITLE
Remove unused Plan fields

### DIFF
--- a/src/core/planner.py
+++ b/src/core/planner.py
@@ -34,9 +34,6 @@ class Plan(TypedDict, total=False):
     planned_orders: int
     buy_usd: float
     sell_usd: float
-    sell_results: list[dict[str, Any]]
-    buy_results: list[dict[str, Any]]
-    failed: bool
 
 
 async def _fetch_price(ib, symbol: str, cfg) -> tuple[str, float]:


### PR DESCRIPTION
## Summary
- drop obsolete `sell_results`, `buy_results`, and `failed` keys from the `Plan` typed dict

## Testing
- `pre-commit run --files src/core/planner.py src/core/confirmation.py src/rebalance.py`
- `mypy src/core/planner.py src/core/confirmation.py src/rebalance.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc51842ca0832081029134c4066611