### PR TITLE
chore: remove reports directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .venv/
-reports/*
-!reports/.gitkeep
+# Runtime-generated reports
+reports/
 __pycache__/
 *.pyc
 *.log

--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ python -m src.rebalance --read-only --config config/settings.ini --csv config/po
 Forces preview-only mode even if `--yes` is used.
 
 ### Reporting & logging
-After a run, timestamped artifacts are written under `reports/`:
+After a run, timestamped artifacts are written under `reports/`.
+The directory is created automatically if missing and is not tracked in version control:
 
 ```text
 reports/rebalance_pre_<account>_<timestamp>.csv   # state and intended trades per account


### PR DESCRIPTION
## Summary
- stop tracking empty `reports/` directory and document runtime-generated report path
- clarify in README that `reports/` is auto-created and gitignored

## Testing
- `pre-commit run --files README.md .gitignore`
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68bc5ac024888320ada11df2dc38fa77