### PR TITLE
Fix FakeClient __aexit__ return type

### DIFF
--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -24,8 +24,8 @@ def test_plan_account_builds_targets_from_mix() -> None:
 
         async def __aexit__(
             self, exc_type, exc, tb
-        ) -> bool:  # pragma: no cover - simple stub
-            return False
+        ) -> None:  # pragma: no cover - simple stub
+            return None
 
         async def snapshot(self, account_id):
             return {


### PR DESCRIPTION
## Summary
- align FakeClient.__aexit__ return type with IBKRClient

## Testing
- `pre-commit run --files tests/unit/test_targets.py`
- `PYTHONPATH=. pytest tests/unit/test_targets.py -k test_plan_account_builds_targets_from_mix -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc60646844832091564330111530ea