### PR TITLE
Format tests with Black

### DIFF
--- a/tests/unit/test_confirm_per_account.py
+++ b/tests/unit/test_confirm_per_account.py
@@ -85,7 +85,9 @@ def test_confirm_per_account_applies_overrides(tmp_path):
     def prioritize_by_drift(account_id, drifts, cfg):
         return []
 
-    def size_orders(account_id, drifts, prices, current_positions, cash_after, net_liq, cfg):
+    def size_orders(
+        account_id, drifts, prices, current_positions, cash_after, net_liq, cfg
+    ):
         return [], 0.0, 0.0
 
     def append_run_summary(path, ts_dt, row):

--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -149,9 +149,7 @@ def test_rejects_non_finite_price_or_quantity() -> None:
     drifts = [_drift("AAA", -100.0, net_liq, 100.0)]
     prices = {"AAA": math.nan}
     with pytest.raises(ValueError):
-        size_orders(
-            "ACCT", drifts, prices, {}, cash=200.0, net_liq=net_liq, cfg=cfg
-        )
+        size_orders("ACCT", drifts, prices, {}, cash=200.0, net_liq=net_liq, cfg=cfg)
 
     # Non-finite quantity
     bad_drift = Drift("BBB", 0.0, 0.0, 0.0, math.nan, 1.0, "BUY")


### PR DESCRIPTION
## Summary
- apply Black formatting to test modules for sizing and per-account confirmations

## Testing
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6eac72e0832093cefb1198e5ace8