### PR TITLE
Fetch fresh prices for all target symbols

### DIFF
--- a/src/core/planner.py
+++ b/src/core/planner.py
@@ -129,37 +129,32 @@ async def plan_account(
 
         tasks: list[asyncio.Task[Any]] = []
         try:
-            missing_symbols = {
-                sym for sym in targets if sym not in snapshot_prices and sym != "CASH"
-            }
-            if missing_symbols:
-                await _print(
-                    f"[blue]Fetching prices for {len(missing_symbols)} target symbols[/blue]"
-                )
-                logging.info(
-                    "Fetching prices for %s: %d target symbols",
-                    account_id,
-                    len(missing_symbols),
-                )
-                tasks = [
-                    asyncio.create_task(fetch_price(client._ib, sym, cfg))
-                    for sym in missing_symbols
-                ]
-                for idx, task in enumerate(asyncio.as_completed(tasks), 1):
-                    try:
-                        symbol, price = await task
-                    except PricingError as exc:
-                        await _print(f"[red]{exc}[/red]")
-                        logging.error(str(exc))
-                        for t in tasks:
-                            t.cancel()
-                        await asyncio.gather(*tasks, return_exceptions=True)
-                        raise
-                    snapshot_prices[symbol] = price
-                    await _print(
-                        f"[blue]  ({idx}/{len(missing_symbols)}) {symbol}[/blue]"
-                    )
-                tasks = []
+            target_symbols = {sym for sym in targets if sym != "CASH"}
+            await _print(
+                f"[blue]Fetching prices for {len(target_symbols)} target symbols[/blue]"
+            )
+            logging.info(
+                "Fetching prices for %s: %d target symbols",
+                account_id,
+                len(target_symbols),
+            )
+            tasks = [
+                asyncio.create_task(fetch_price(client._ib, sym, cfg))
+                for sym in target_symbols
+            ]
+            for idx, task in enumerate(asyncio.as_completed(tasks), 1):
+                try:
+                    symbol, price = await task
+                except PricingError as exc:
+                    await _print(f"[red]{exc}[/red]")
+                    logging.error(str(exc))
+                    for t in tasks:
+                        t.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
+                snapshot_prices[symbol] = price
+                await _print(f"[blue]  ({idx}/{len(target_symbols)}) {symbol}[/blue]")
+            tasks = []
 
             await _print("[blue]Computing drift[/blue]")
             logging.info("Computing drift for %s", account_id)

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -110,8 +110,9 @@ def test_run_fetches_prices_for_targets_and_trades(
     )
     asyncio.run(rebalance._run(args))
 
-    assert pre == {"AAA": 10.0, "BBB": 20.0}
-    assert fetched == ["BBB", "AAA"]
+    assert pre == {"AAA": 15.0, "BBB": 20.0}
+    assert fetched.count("AAA") == 2
+    assert fetched.count("BBB") == 1
     assert sizing == {"AAA": 15.0}
 
 
@@ -138,5 +139,5 @@ def test_run_aborts_when_trade_price_unavailable(
     out, _ = capsys.readouterr()
     assert "bad price" in out
     assert pre == {}
-    assert fetched == ["BBB"]
+    assert sorted(fetched) == ["AAA", "BBB"]
     assert sizing == {}

--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -55,6 +55,9 @@ def test_plan_account_builds_targets_from_mix() -> None:
         "CASH": {},
     }
 
+    async def fake_fetch_price(*args, **kwargs):
+        return "", 0.0
+
     plan = asyncio.run(
         plan_account(
             "A",
@@ -65,7 +68,7 @@ def test_plan_account_builds_targets_from_mix() -> None:
             compute_drift=lambda *args, **kwargs: [],
             prioritize_by_drift=lambda *args, **kwargs: [],
             size_orders=lambda *args, **kwargs: ([], 0.0, 0.0),
-            fetch_price=lambda *args, **kwargs: ("", 0.0),
+            fetch_price=fake_fetch_price,
             render_preview=lambda *args, **kwargs: "",
             write_pre_trade_report=lambda *args, **kwargs: None,
         )


### PR DESCRIPTION
## Summary
- refresh prices for every target symbol to remove reliance on snapshot data
- update unit tests for new pricing behavior

## Testing
- `pre-commit run --files src/core/planner.py tests/unit/test_rebalance_pricing.py tests/unit/test_targets.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc751836308320aa18ef1e35f46f07