### PR TITLE
Limit planner price lookup to unpriced symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ from src.core.pricing import get_price
 price = await get_price(ib, "SPY", price_source="last", fallback_to_snapshot=True)
 ```
 
+When planning a rebalance, prices are requested only for current holdings
+without snapshot values and symbols that have a non-zero target weight but
+aren't already priced.
+
 ### Drift preview
 Generate a table of drift metrics:
 

--- a/src/core/planner.py
+++ b/src/core/planner.py
@@ -132,7 +132,15 @@ async def plan_account(
 
         tasks: list[asyncio.Task[Any]] = []
         try:
-            target_symbols = {sym for sym in targets if sym != "CASH"}
+            missing_current = {
+                sym for sym in current if sym != "CASH" and sym not in snapshot_prices
+            }
+            needed_targets = {
+                sym
+                for sym, wt in targets.items()
+                if sym != "CASH" and wt != 0 and sym not in snapshot_prices
+            }
+            target_symbols = missing_current | needed_targets
             await _print(
                 f"[blue]Fetching prices for {len(target_symbols)} target symbols[/blue]"
             )

--- a/tests/unit/test_planner_pricing_scope.py
+++ b/tests/unit/test_planner_pricing_scope.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from typing import cast
+
+from src.broker.ibkr_client import IBKRClient
+from src.core.drift import Drift
+from src.core.planner import plan_account
+from src.io import AppConfig
+
+
+def test_plan_account_fetches_only_needed_prices() -> None:
+    class FakeClient(IBKRClient):
+        def __init__(self) -> None:  # pragma: no cover - simple stub
+            self._ib = object()
+
+        async def __aenter__(self) -> "FakeClient":  # pragma: no cover - simple stub
+            return self
+
+        async def __aexit__(
+            self, exc_type, exc, tb
+        ) -> None:  # pragma: no cover - simple stub
+            return None
+
+        async def snapshot(self, account_id):
+            return {
+                "positions": [
+                    {"symbol": "AAA", "position": 1.0, "market_price": 10.0},
+                    {"symbol": "BBB", "position": 1.0},
+                ],
+                "cash": 0.0,
+                "net_liq": 0.0,
+            }
+
+    cfg = cast(
+        AppConfig,
+        SimpleNamespace(
+            ibkr=SimpleNamespace(host="h", port=1, client_id=1),
+            models=SimpleNamespace(smurf=1.0, badass=0.0, gltr=0.0),
+            pricing=SimpleNamespace(price_source="last", fallback_to_snapshot=True),
+            io=SimpleNamespace(report_dir="reports", log_level="INFO"),
+        ),
+    )
+
+    portfolios = {
+        "AAA": {"smurf": 1.0},
+        "BBB": {"smurf": 1.0},
+        "CCC": {"smurf": 1.0},
+        "CASH": {},
+    }
+
+    fetched: list[str] = []
+
+    async def fake_fetch_price(ib, symbol, cfg):
+        fetched.append(symbol)
+        return symbol, 1.0
+
+    def fake_compute_drift(account_id, current, targets, prices, net_liq, cfg):
+        return [
+            Drift("AAA", 0, 0, -1.0, -1.0, prices["AAA"], "BUY"),
+            Drift("BBB", 0, 0, -1.0, -1.0, prices["BBB"], "BUY"),
+            Drift("CCC", 0, 0, -1.0, -1.0, prices["CCC"], "BUY"),
+        ]
+
+    asyncio.run(
+        plan_account(
+            "A",
+            portfolios,
+            cfg,
+            datetime.now(),
+            client_factory=FakeClient,
+            compute_drift=fake_compute_drift,
+            prioritize_by_drift=lambda account_id, drifts, cfg: drifts,
+            size_orders=lambda *args, **kwargs: ([], 0.0, 0.0),
+            fetch_price=fake_fetch_price,
+            render_preview=lambda *args, **kwargs: "",
+            write_pre_trade_report=lambda *args, **kwargs: None,
+        )
+    )
+
+    assert sorted(fetched) == ["BBB", "CCC"]

--- a/tests/unit/test_rebalance_pricing.py
+++ b/tests/unit/test_rebalance_pricing.py
@@ -110,10 +110,10 @@ def test_run_fetches_prices_for_targets_and_trades(
     )
     asyncio.run(rebalance._run(args))
 
-    assert pre == {"AAA": 15.0, "BBB": 20.0}
-    assert fetched.count("AAA") == 1
+    assert pre == {"AAA": 10.0, "BBB": 20.0}
+    assert fetched.count("AAA") == 0
     assert fetched.count("BBB") == 1
-    assert sizing == {"AAA": 15.0}
+    assert sizing == {"AAA": 10.0}
 
 
 def test_run_aborts_when_trade_price_unavailable(
@@ -139,5 +139,5 @@ def test_run_aborts_when_trade_price_unavailable(
     out, _ = capsys.readouterr()
     assert "bad price" in out
     assert pre == {}
-    assert sorted(fetched) == ["AAA", "BBB"]
+    assert sorted(fetched) == ["BBB"]
     assert sizing == {}


### PR DESCRIPTION
## Summary
- Avoid fetching prices for already-priced or zero-weight symbols when planning trades
- Verify that planner only queries prices for symbols needing trades
- Document the narrower price-fetching scope

## Testing
- `pre-commit run --files src/core/planner.py tests/unit/test_planner_pricing_scope.py tests/unit/test_rebalance_pricing.py README.md`
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7d4564c4832081c053a43d27e7ab