### PR TITLE
Ignore zero-weight targets without holdings

### DIFF
--- a/src/core/drift.py
+++ b/src/core/drift.py
@@ -129,17 +129,18 @@ def compute_drift(
         for sym, val in values.items()
     }
 
-    # Union of all symbols from current holdings and targets.
-    symbols = set(current_wts) | set(targets)
+    # Ignore zero-weight targets when building the symbol universe.
+    non_zero_targets = {s: wt for s, wt in targets.items() if wt != 0}
+    symbols = set(current_wts) | set(non_zero_targets)
 
     # Ensure target-only symbols have associated pricing data.
-    for sym in set(targets) - set(current_wts):
+    for sym in set(non_zero_targets) - set(current_wts):
         if sym != "CASH" and sym not in prices:
             raise KeyError(f"missing price for {sym}")
 
     drifts: list[Drift] = []
     for symbol in sorted(symbols):
-        target = targets.get(symbol, 0.0)
+        target = non_zero_targets.get(symbol, 0.0)
         current_wt = current_wts.get(symbol, 0.0)
         drift_pct = current_wt - target
         drift_usd = investable_net_liq * drift_pct / 100.0

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -135,6 +135,19 @@ def test_compute_drift_missing_price_for_target_raises() -> None:
         compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
 
 
+def test_compute_drift_ignores_zero_weight_targets_without_holdings() -> None:
+    """Zero-weight targets lacking holdings don't require pricing."""
+
+    current = {"AAA": 10, "CASH": 5000}
+    targets = {"AAA": 50.0, "BBB": 0.0}
+    prices = {"AAA": 100.0}  # No BBB price provided
+    net_liq = 6000.0
+
+    drifts = compute_drift("ACCT", current, targets, prices, net_liq, cfg=None)
+    symbols = {d.symbol for d in drifts}
+    assert symbols == {"AAA", "CASH"}
+
+
 def test_compute_drift_defaults_missing_targets_to_zero() -> None:
     """Symbols absent from targets are treated as having 0% target weight."""
 

--- a/tests/unit/test_planner_pricing_scope.py
+++ b/tests/unit/test_planner_pricing_scope.py
@@ -48,6 +48,7 @@ def test_plan_account_fetches_only_needed_prices() -> None:
         "AAA": {"smurf": 1.0},
         "BBB": {"smurf": 1.0},
         "CCC": {"smurf": 1.0},
+        "DDD": {"smurf": 0.0},
         "CASH": {},
     }
 


### PR DESCRIPTION
## Summary
- Skip zero-weight targets when calculating drift and validating prices
- Ensure planning ignores zero-weight symbols and doesn't fetch their prices
- Add tests for zero-weight targets without holdings

## Testing
- `pytest tests/unit/test_drift.py tests/unit/test_planner_pricing_scope.py -q`
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc827ce12483208e65704824b83bc1