### PR TITLE
Include market prices in IBKR snapshot positions

### DIFF
--- a/tests/integration/test_ibkr_snapshot.py
+++ b/tests/integration/test_ibkr_snapshot.py
@@ -26,3 +26,5 @@ def test_ibkr_snapshot():
     snapshot = asyncio.run(run())
     assert isinstance(snapshot["net_liq"], (int, float))
     assert isinstance(snapshot["positions"], list)
+    for pos in snapshot["positions"]:
+        assert "market_price" in pos

--- a/tests/unit/test_ibkr_client.py
+++ b/tests/unit/test_ibkr_client.py
@@ -42,6 +42,37 @@ class FakeIBSnapshot:
             ),
         ]
 
+    async def reqAccountUpdatesAsync(self, account):
+        return None
+
+    def portfolio(self):
+        return [
+            SimpleNamespace(
+                account="ACC",
+                contract=SimpleNamespace(symbol="AAPL", currency="USD"),
+                position=10,
+                marketPrice=110.0,
+                marketValue=1100.0,
+                averageCost=100.0,
+            ),
+            SimpleNamespace(
+                account="ACC",
+                contract=SimpleNamespace(symbol="SHOP", currency="CAD"),
+                position=5,
+                marketPrice=150.0,
+                marketValue=750.0,
+                averageCost=150.0,
+            ),
+            SimpleNamespace(
+                account="OTHER",
+                contract=SimpleNamespace(symbol="MSFT", currency="USD"),
+                position=20,
+                marketPrice=200.0,
+                marketValue=4000.0,
+                averageCost=200.0,
+            ),
+        ]
+
     async def reqAccountSummaryAsync(self, account_id):
         return None
 
@@ -66,6 +97,8 @@ def test_snapshot_converts_cad_cash(monkeypatch):
                 "symbol": "AAPL",
                 "position": 10,
                 "avg_cost": 100.0,
+                "market_price": 110.0,
+                "market_value": 1100.0,
             }
         ],
         "cash": 1000.0,
@@ -96,6 +129,8 @@ def test_snapshot_cad_cash_no_fx_rate(monkeypatch):
                 "symbol": "AAPL",
                 "position": 10,
                 "avg_cost": 100.0,
+                "market_price": 110.0,
+                "market_value": 1100.0,
             }
         ],
         "cash": 1000.0,


### PR DESCRIPTION
## Summary
- pull portfolio data via `reqAccountUpdatesAsync` so positions include market and value data
- add `market_price` (and value) to each USD position in `snapshot`
- extend tests to assert `market_price` is returned

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8a29990883208066a7e4c34f127c