### PR TITLE
Handle missing market prices in planner

### DIFF
--- a/tests/unit/test_planner_pricing_scope.py
+++ b/tests/unit/test_planner_pricing_scope.py
@@ -82,3 +82,72 @@ def test_plan_account_fetches_only_needed_prices() -> None:
     )
 
     assert sorted(fetched) == ["BBB", "CCC"]
+
+
+def test_plan_account_fetches_price_for_avg_cost_position() -> None:
+    """Positions reporting only average cost should trigger price fetch."""
+
+    class FakeClient(IBKRClient):
+        def __init__(self) -> None:  # pragma: no cover - simple stub
+            self._ib = object()
+
+        async def __aenter__(self) -> "FakeClient":  # pragma: no cover - simple stub
+            return self
+
+        async def __aexit__(
+            self, exc_type, exc, tb
+        ) -> None:  # pragma: no cover - simple stub
+            return None
+
+        async def snapshot(self, account_id):
+            return {
+                "positions": [
+                    {"symbol": "AAA", "position": 1.0, "avg_cost": 10.0},
+                ],
+                "cash": 0.0,
+                "net_liq": 0.0,
+            }
+
+    cfg = cast(
+        AppConfig,
+        SimpleNamespace(
+            ibkr=SimpleNamespace(host="h", port=1, client_id=1),
+            models=SimpleNamespace(smurf=1.0, badass=0.0, gltr=0.0),
+            pricing=SimpleNamespace(price_source="last", fallback_to_snapshot=True),
+            io=SimpleNamespace(report_dir="reports", log_level="INFO"),
+        ),
+    )
+
+    portfolios = {
+        "AAA": {"smurf": 1.0},
+        "CASH": {},
+    }
+
+    fetched: list[str] = []
+
+    async def fake_fetch_price(ib, symbol, cfg):
+        fetched.append(symbol)
+        return symbol, 1.0
+
+    def fake_compute_drift(account_id, current, targets, prices, net_liq, cfg):
+        return [
+            Drift("AAA", 0, 0, -1.0, -1.0, prices["AAA"], "BUY"),
+        ]
+
+    asyncio.run(
+        plan_account(
+            "A",
+            portfolios,
+            cfg,
+            datetime.now(),
+            client_factory=FakeClient,
+            compute_drift=fake_compute_drift,
+            prioritize_by_drift=lambda account_id, drifts, cfg: drifts,
+            size_orders=lambda *args, **kwargs: ([], 0.0, 0.0),
+            fetch_price=fake_fetch_price,
+            render_preview=lambda *args, **kwargs: "",
+            write_pre_trade_report=lambda *args, **kwargs: None,
+        )
+    )
+
+    assert fetched == ["AAA"]


### PR DESCRIPTION
## Summary
- ignore snapshot avg_cost, only use positive market_price values
- queue missing/invalid prices for fetching
- cover avg_cost-only positions fetching a real price

## Testing
- `PYTHONPATH=. pytest tests/unit/test_planner_pricing_scope.py -q`
- `ruff check src/core/planner.py tests/unit/test_planner_pricing_scope.py`
- `black --check src/core/planner.py tests/unit/test_planner_pricing_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc8b0a6e988320bc36245db5b38e7b