### PR TITLE
Add timeout and cancellation for IBKR account updates

### DIFF
--- a/tests/unit/test_ibkr_client.py
+++ b/tests/unit/test_ibkr_client.py
@@ -14,6 +14,9 @@ from src.broker.ibkr_client import IBKRClient
 
 
 class FakeIBSnapshot:
+    def __init__(self):
+        self.client = SimpleNamespace(reqAccountUpdates=lambda subscribe, account: None)
+
     async def connectAsync(self, host, port, clientId):
         return None
 
@@ -138,6 +141,30 @@ def test_snapshot_cad_cash_no_fx_rate(monkeypatch):
     }
     symbols = {p["symbol"] for p in result["positions"]}
     assert "MSFT" not in symbols
+
+
+class SlowIBSnapshot(FakeIBSnapshot):
+    def __init__(self):
+        super().__init__()
+        self.cancel_called = False
+        self.client = SimpleNamespace(reqAccountUpdates=self._cancel)
+
+    async def reqAccountUpdatesAsync(self, account):
+        await asyncio.sleep(0.2)
+
+    def _cancel(self, subscribe, account):
+        if not subscribe:
+            self.cancel_called = True
+
+
+def test_snapshot_times_out(monkeypatch):
+    slow_ib = SlowIBSnapshot()
+    monkeypatch.setattr(ibkr_client, "IB", lambda: slow_ib)
+    client = IBKRClient(account_updates_timeout=0.05)
+    with pytest.raises(IBKRError) as exc:
+        asyncio.run(client.snapshot("ACC"))
+    assert "timed out" in str(exc.value)
+    assert slow_ib.cancel_called
 
 
 class FailingIB:


### PR DESCRIPTION
## Summary
- add configurable account update timeout and cancel subscription after snapshot
- raise IBKRError if account updates request times out
- test snapshot timeout and cancellation

## Testing
- `pre-commit run --files src/broker/ibkr_client.py tests/unit/test_ibkr_client.py`
- `pytest tests/unit/test_ibkr_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc92e195888320a16eefddea726ad0